### PR TITLE
add editable footer snippet

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -30,21 +30,21 @@ class Article(Page):
 
 @register_snippet
 class Footer(models.Model):
-    title = models.CharField(max_length=255, blank=True)
+    title = models.CharField(max_length=255)
     logos = StreamField([
-        ('image', ImageChooserBlock())
-    ], null=True)
+        ('image', ImageChooserBlock(required=False))
+    ], blank=True)
     navigation = StreamField([
         ('link_group', blocks.StructBlock([
             ('title', blocks.CharBlock()),
             ('links', blocks.StreamBlock([
                 ('page', blocks.PageChooserBlock())
             ]))
-        ]))
-    ], null=True)
+        ], required=False))
+    ], blank=True)
     essential = StreamField([
         ('page', blocks.PageChooserBlock()),
-    ], null=True)
+    ])
 
     panels = [
         FieldPanel('title'),

--- a/home/models.py
+++ b/home/models.py
@@ -3,8 +3,9 @@ from django.db import models
 from wagtail.core import blocks
 from wagtail.core.models import Page
 from wagtail.core.fields import StreamField
-from wagtail.admin.edit_handlers import StreamFieldPanel
+from wagtail.admin.edit_handlers import StreamFieldPanel, FieldPanel
 from wagtail.images.blocks import ImageChooserBlock
+from wagtail.snippets.models import register_snippet
 
 
 class HomePage(Page):
@@ -26,3 +27,31 @@ class Article(Page):
     content_panels = Page.content_panels + [
         StreamFieldPanel('body')
     ]
+
+@register_snippet
+class Footer(models.Model):
+    title = models.CharField(max_length=255, blank=True)
+    logos = StreamField([
+        ('image', ImageChooserBlock())
+    ], null=True)
+    navigation = StreamField([
+        ('link_group', blocks.StructBlock([
+            ('title', blocks.CharBlock()),
+            ('links', blocks.StreamBlock([
+                ('page', blocks.PageChooserBlock())
+            ]))
+        ]))
+    ], null=True)
+    essential = StreamField([
+        ('page', blocks.PageChooserBlock()),
+    ], null=True)
+
+    panels = [
+        FieldPanel('title'),
+        StreamFieldPanel('logos'),
+        StreamFieldPanel('navigation'),
+        StreamFieldPanel('essential'),
+    ]
+
+    def __str__(self):
+        return self.title

--- a/home/templates/home/tags/footer.html
+++ b/home/templates/home/tags/footer.html
@@ -1,0 +1,27 @@
+{% load static wagtailcore_tags wagtailimages_tags %}
+<footer class="footer">
+    <nav>
+        {% for block in footer.navigation %}
+        <div class="links">
+            <span>{{block.value.title}}</span>
+            {% for link in block.value.links %}
+            <a href="{% pageurl link.value %}">{{link.value.title}}</a>
+            {% endfor %}
+        </div>
+        {% endfor %}
+    </nav>
+
+    <div class="copyright">
+        <div class="logo">
+            {% for block in footer.logos %}
+            {% image block.value width-150 %}
+            {% endfor %}
+        </div>
+        <div class="links">
+            {% for block in footer.essential %}
+            <a href="{% pageurl block.value %}">{{block.value.title}}</a>
+            {% endfor %}
+        </div>
+    </div>
+
+</footer>

--- a/home/templatetags/home_tags.py
+++ b/home/templatetags/home_tags.py
@@ -1,0 +1,11 @@
+from django import template
+from home.models import Footer
+
+register = template.Library()
+
+@register.inclusion_tag('home/tags/footer.html', takes_context=True)
+def footer(context):
+    return {
+        'footer': Footer.objects.all()[0],
+        'request': context['request'],
+    }

--- a/home/templatetags/home_tags.py
+++ b/home/templatetags/home_tags.py
@@ -6,6 +6,6 @@ register = template.Library()
 @register.inclusion_tag('home/tags/footer.html', takes_context=True)
 def footer(context):
     return {
-        'footer': Footer.objects.all()[0],
+        'footer': Footer.objects.first(),
         'request': context['request'],
     }

--- a/iogt/static/css/footer.css
+++ b/iogt/static/css/footer.css
@@ -14,6 +14,7 @@
   font-size: 100%;
   border-bottom: 1px solid #dadada;
   margin-bottom: 3%;
+  text-transform: uppercase;
 }
 
 .footer nav .links {

--- a/iogt/templates/base.html
+++ b/iogt/templates/base.html
@@ -1,4 +1,4 @@
-{% load static wagtailuserbar %}
+{% load static wagtailuserbar home_tags %}
 <!DOCTYPE html>
 <html class="no-js" lang="en">
     <head>
@@ -36,7 +36,7 @@
 
                 {% block content %}{% endblock %}
 
-                {% include "footer.html" %}
+                {% footer %}
             </div>
         </div>
 


### PR DESCRIPTION
Related to issue #19 . A fully editable footer snippet that allows changes to navigation links, logos and the "essential" links to privacy policy, terms of use, etc. All links are to pages within the site. 