### PR TITLE
Add wagtail-localize

### DIFF
--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/3.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
+from django.utils.translation import gettext_lazy as _
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
@@ -41,6 +42,8 @@ INSTALLED_APPS = [
     'wagtail.contrib.modeladmin',
     'wagtailmenus',
     'wagtailmedia',
+    'wagtail_localize',
+    'wagtail_localize.locales',
 
     'modelcluster',
     'taggit',
@@ -128,7 +131,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'en'
 
 TIME_ZONE = 'UTC'
 
@@ -189,7 +192,7 @@ WAGTAIL_USER_CUSTOM_FIELDS = ['display_name', 'terms_accepted']
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
-BASE_URL = 'http://example.com'
+BASE_URL = 'http://iogt.site'
 
 # SITE ID
 SITE_ID = 1
@@ -198,3 +201,10 @@ SITE_ID = 1
 LOGIN_REDIRECT_URL = "/"
 LOGIN_URL = 'account_login'
 WAGTAIL_FRONTEND_LOGIN_URL = LOGIN_URL
+
+WAGTAIL_I18N_ENABLED = True
+
+WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
+    ('en', _('English')),
+    ('fr', _('French')),
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ wagtailmedia==0.7.0
 wagtailmenus~=3.0
 elasticsearch>=7.0.0,<8.0.0
 django-allauth~=0.44
+wagtail-localize~=0.9.5


### PR DESCRIPTION
`wagtail-localize` has all of the capabilities that we should need for managing language translation (see [overview video](https://www.youtube.com/watch?v=mEzQcOMUzoc)).

If additional tools are needed in the translation workflow then we can convert the `.po` files that are used by Wagtail and Django into other formats.  Users who work directly with `.po` files (instead of using the Wagtail admin interface) could install and use [Poedit](https://poedit.net/).