### PR TITLE
Minor housekeeping

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,5 @@ ENV PYTHONUNBUFFERED 1
 WORKDIR ./
 
 RUN pip install --upgrade pip
-RUN apt-get update
-
 ADD ./requirements.txt /app/
 RUN pip install -r /app/requirements.txt

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,11 @@
-FROM python:3.8.1-slim-buster
+FROM python:3.8.1-buster
 
 ENV PYTHONUNBUFFERED 1
 
 WORKDIR ./
 
 RUN pip install --upgrade pip
+RUN apt-get update
+
 ADD ./requirements.txt /app/
 RUN pip install -r /app/requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       - elastic
   elasticsearch:
     image: 'docker.elastic.co/elasticsearch/elasticsearch:7.12.1'
-    container_name: 'iogt-es01'
     environment:
       - discovery.type=single-node
     volumes:


### PR DESCRIPTION
Installing psycopg2 needed libpq-dev python3-dev and build-essential. Since this is just the development setup, keeping it simple and not installing them explicitly