### PR TITLE
Add language-specific menus using flat menus

### DIFF
--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -84,6 +84,9 @@ MIDDLEWARE = [
     'external_links.middleware.RewriteExternalLinksMiddleware',
 ]
 
+# Prevent Wagtail's built in menu from showing in Admin > Settings
+WAGTAILMENUS_MAIN_MENUS_EDITABLE_IN_WAGTAILADMIN = False
+
 ROOT_URLCONF = 'iogt.urls'
 
 TEMPLATES = [

--- a/iogt/templates/header.html
+++ b/iogt/templates/header.html
@@ -112,7 +112,7 @@
                         </a>
                     {% endcomment %}
 
-                        {% flat_menu LANGUAGE_CODE|add:'_menu' max_levels=1 show_menu_heading=False  fall_back_to_default_site_menus=True %}
+                        {% flat_menu LANGUAGE_CODE|add:'_menu_live' max_levels=1 show_menu_heading=False  fall_back_to_default_site_menus=True %}
 
                     </span>
                 </dl>

--- a/iogt/templates/header.html
+++ b/iogt/templates/header.html
@@ -1,4 +1,9 @@
 {% load static menu_tags %}
+{% load i18n %}
+
+{% get_current_language as LANGUAGE_CODE %}
+
+
 <header class="header">
     <div class="header-top">
         <div class="header-top-language-strip">
@@ -34,6 +39,7 @@
                 </div>
             </div>
         </div>
+
         <div class="header-middle">
             <a class="logo-small" href='/'>
                 <img src="{% static "images/iogt-logo-two-lines.png" %}"/>
@@ -94,6 +100,8 @@
             <div class="categories-dropdown-content">
                 <dl>
                     <span>
+
+                    {% comment %}
                         <a class="dl-title" href='/'>
                             <dt>Topic title
                                 <i class="material-icons">arrow_drop_up</i>
@@ -102,6 +110,10 @@
                         <a class="dl-item" href='/'>
                             <dd>Topic item</dd>
                         </a>
+                    {% endcomment %}
+
+                        {% flat_menu LANGUAGE_CODE|add:'_menu' max_levels=1 show_menu_heading=False  fall_back_to_default_site_menus=True %}
+
                     </span>
                 </dl>
             </div>


### PR DESCRIPTION
`Admin > Settings > Flat Menus` can now be used to create language-specific top-level menus for each required language.

When templates are rendered, the current language code will be automatically detected - this language code is then used to display the correct menu.

In order for the correct menu to be chosen, the menu's `Handle` must be set to `en_menu_live` for English, `fr_menu_live` for French, etc.

Only the overall menu requires the `Handle` to be set, the individual menu items within a menu do not require a `Handle` value.

This PR also disables (hides) Wagtail's standard "Main Menu" option from `Admin > Settings` to avoid confusion.

Resolves 137, resolves 144.