### PR TITLE
Update .gitignore to exclude compiled translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ legacy-initdb.d/
 
 !iogt/templates/wagtailmedia/media/
 .vscode/
+
+# Translations
+*.mo


### PR DESCRIPTION
`.mo` files are created during the build process using `./manage.py compilemessages`