### PR TITLE
Register urls for precache

### DIFF
--- a/iogt/static/manifest/manifest.webmanifest
+++ b/iogt/static/manifest/manifest.webmanifest
@@ -2,7 +2,7 @@
     "name": "IOGT",
     "short_name": "iogt",
     "start_url": "/",
-    "scope": "http://localhost:8000/",
+    "scope": "/",
     "display": "standalone",
     "background_color": "#FFF",
     "theme_color": "#493174",


### PR DESCRIPTION
- Uses sitemap API to fetch URLs to use in precache
- All Pages (homepage, sections, articles, footers, polls, surveys, quizzes) will be cached