### PR TITLE
Add code for Google Analytics

### DIFF
--- a/iogt/templates/base.html
+++ b/iogt/templates/base.html
@@ -4,6 +4,16 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ settings.home.SiteSettings.local_ga_tracking_code }}"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){window.dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '{{ settings.home.SiteSettings.local_ga_tag_manager }}');
+        gtag('config', '{{ settings.home.SiteSettings.global_ga_tag_manager }}');
+        gtag('config', '{{ settings.home.SiteSettings.local_ga_tracking_code }}');
+        gtag('config', '{{ settings.home.SiteSettings.global_ga_tracking_code }}');
+    </script>
     <meta charset="utf-8"/>
     <title>
         {% block title %}


### PR DESCRIPTION
Adds traditional Universal Analytics (UA) and Google Analytics 4 (GA4) tracking to `base.html` at the same time as per documentation [here](https://developers.google.com/analytics/devguides/collection/ga4/basic-tag?technology=gtagjs).

The settings page already allows the local site and overall global tracking UA and GA4 properties to all be entered.

![ga_example](https://user-images.githubusercontent.com/2097922/124979045-78828500-e02a-11eb-9e06-8e2149914f5c.jpg)

Resolves #22