### PR TITLE
adds a skip locales flag to load v1 db command

### DIFF
--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -41,10 +41,16 @@ class Command(BaseCommand):
             required=True,
             help='Path to IoGT v1 media directory'
         )
+        parser.add_argument(
+            '--skip-locales',
+            action='store_true',
+            help='Path to IoGT v1 media directory'
+        )
 
     def handle(self, *args, **options):
         self.db_connect(options)
         self.media_dir = options.get('media_dir')
+        self.skip_locales = options.get('skip_locales')
 
         self.clear()
         self.stdout.write('Existing site structure cleared')
@@ -101,7 +107,10 @@ class Command(BaseCommand):
         Page.fix_tree()
 
     def create_home_page(self, root):
-        cur = self.db_query('select * from core_main main join wagtailcore_page page on main.page_ptr_id = page.id')
+        sql = 'select * from core_main main join wagtailcore_page page on main.page_ptr_id = page.id'
+        if self.skip_locales:
+            sql += " where slug not like '%translation-of%'"
+        cur = self.db_query(sql)
         main = cur.fetchone()
         cur.close()
         home = None
@@ -194,7 +203,11 @@ class Command(BaseCommand):
         return tags
 
     def migrate_sections(self, section_index_page):
-        cur = self.db_query('select * from core_sectionpage csp join wagtailcore_page wcp on csp.page_ptr_id  = wcp.id order by wcp.path')
+        sql = 'select * from core_sectionpage csp join wagtailcore_page wcp on csp.page_ptr_id = wcp.id'
+        if self.skip_locales:
+            sql += " where slug not like '%translation-of%'"
+        sql += ' order by wcp.path'
+        cur = self.db_query(sql)
         for row in cur:
             self.create_section(section_index_page, row)
         cur.close()
@@ -215,7 +228,11 @@ class Command(BaseCommand):
         self.stdout.write(f"saved section, title={section.title}")
 
     def migrate_articles(self, section_index_page):
-        cur = self.db_query("select * from core_articlepage cap join wagtailcore_page wcp on cap.page_ptr_id  = wcp.id where wcp.path like '000100010002%' order by wcp.path")
+        sql = "select * from core_articlepage cap join wagtailcore_page wcp on cap.page_ptr_id = wcp.id where wcp.path like '000100010002%'"
+        if self.skip_locales:
+            sql += " and slug not like '%translation-of%'"
+        sql += ' order by wcp.path'
+        cur = self.db_query(sql)
         for row in cur:
             self.create_article(section_index_page, row)
         cur.close()
@@ -243,7 +260,11 @@ class Command(BaseCommand):
         return json.dumps(v2_body)
 
     def migrate_banners(self, banner_index_page):
-        cur = self.db_query("select * from core_bannerpage cbp join wagtailcore_page wcp on cbp.page_ptr_id  = wcp.id order by wcp.path")
+        sql = "select * from core_bannerpage cbp join wagtailcore_page wcp on cbp.page_ptr_id = wcp.id"
+        if self.skip_locales:
+            sql += " where slug not like '%translation-of%'"
+        sql += ' order by wcp.path'
+        cur = self.db_query(sql)
         for row in cur:
             self.create_banner(banner_index_page, row)
         cur.close()
@@ -263,7 +284,11 @@ class Command(BaseCommand):
         self.stdout.write(f"saved banner, title={banner.title}")
 
     def migrate_footers(self, footer_index_page):
-        cur = self.db_query("select * from core_footerpage cfp join core_articlepage cap on cfp.articlepage_ptr_id = cap.page_ptr_id join wagtailcore_page wcp on cap.page_ptr_id = wcp.id order by wcp.path")
+        sql = "select * from core_footerpage cfp join core_articlepage cap on cfp.articlepage_ptr_id = cap.page_ptr_id join wagtailcore_page wcp on cap.page_ptr_id = wcp.id"
+        if self.skip_locales:
+            sql += " where slug not like '%translation-of%'"
+        sql += ' order by wcp.path'
+        cur = self.db_query(sql)
         for row in cur:
             self.create_footer(footer_index_page, row)
         cur.close()

--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '--skip-locales',
             action='store_true',
-            help='Path to IoGT v1 media directory'
+            help='Skip data of locales other than default language'
         )
 
     def handle(self, *args, **options):


### PR DESCRIPTION
Fixes #337 

- Added a skip-locales flag to load_v1_db management command
- Data of locales other than Default locale will be filtered out by giving above-mentioned flag