### PR TITLE
removes back button on start page of poll, quiz, and survey

### DIFF
--- a/questionnaires/templates/poll/poll.html
+++ b/questionnaires/templates/poll/poll.html
@@ -6,7 +6,6 @@
 {% endblock %}
 
 {% block content %}
-    {% include 'back_button.html' with back_url=back_url %}
     <div class="polls">
         <div class="polls-widget">
             <div class="container">

--- a/questionnaires/templates/quizzes/quiz.html
+++ b/questionnaires/templates/quizzes/quiz.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static i18n questionnaires_tags wagtailcore_tags %}
+{% load static i18n home_tags questionnaires_tags wagtailcore_tags %}
 {% get_current_language as LANGUAGE_CODE %}
 
 {% block extra_css %}
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block content %}
-    {% include 'back_button.html' with back_url=back_url %}
     <div class="quiz-page">
         <div class="container">
             <h1 class="title quiz-page__title">{{ page.title }}</h1>

--- a/questionnaires/templates/survey/survey.html
+++ b/questionnaires/templates/survey/survey.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load questionnaires_tags %}
+{% load home_tags questionnaires_tags %}
 {% load static wagtailcore_tags i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 
@@ -11,7 +11,6 @@
 
 {% block content %}
     <div class="survey-page">
-        {% include 'back_button.html' with back_url=back_url %}
         <div class="container">
             <h1 class="title survey-page__title">{{ page.title }}</h1>
             {% if page.description %}


### PR DESCRIPTION
Fixes #364 

- removes back button on start page of poll, quiz, and survey
- fixes broken rendering of quiz and survey due to missing template tag 