### PR TITLE
adds help text to redirect from field

### DIFF
--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -6,6 +6,7 @@ from django.urls import resolve
 from django.urls import reverse
 from django.utils.html import escape
 from django.utils.translation import gettext_lazy as _
+from wagtail.contrib.redirects.models import Redirect
 from wagtail.core import hooks
 from wagtail.core.models import Page
 from wagtail.core.models import PageViewRestriction
@@ -82,3 +83,8 @@ def limit_page_chooser(pages, request):
         pages = Page.objects.get(id=page_id).get_children()
 
     return pages
+
+
+Redirect._meta.get_field("old_path").help_text = _(
+    'A relative path to redirect from e.g. /en/youth. '
+    'See https://docs.wagtail.io/en/stable/editor_manual/managing_redirects.html for more details')


### PR DESCRIPTION
fixes #143 

- Adds help text to "Redirect from" field in Redirects form

<img width="831" alt="Screenshot 2021-08-10 at 12 15 46 PM" src="https://user-images.githubusercontent.com/49383675/128824444-fb77c616-4065-4f46-9dfa-35e3c995d859.png">
