### PR TITLE
adds page live link in comments listing

### DIFF
--- a/comments/wagtail_hooks.py
+++ b/comments/wagtail_hooks.py
@@ -21,7 +21,7 @@ class XtdCommentAdmin(ModelAdmin):
     model = XtdComment
     menu_label = 'All Comments'
     menu_icon = 'edit'
-    list_display = ('comment', 'user', 'status', 'num_flags', 'num_replies', 'submit_date')
+    list_display = ('comment', 'user', 'status', 'num_flags', 'num_replies', 'submit_date', 'view_live')
     list_filter = (FlaggedFilter, 'is_removed', 'is_public', 'submit_date',)
     form_fields_exclude = ('thread_id', 'parent_id', 'level', 'order', 'followup', 'nested_count',
                            'content_type', 'object_id', 'user_email', 'user_url')
@@ -47,6 +47,16 @@ class XtdCommentAdmin(ModelAdmin):
 
     def num_flags(self, obj):
         return obj.flags.count()
+
+    def view_live(self, obj):
+        content_object = obj.content_object
+        url = getattr(content_object, 'url', None)
+        if url:
+            return f'<a href="{url}" target="_blank">{content_object.title}</a>'
+
+        return 'N/A'
+
+    view_live.allow_tags = True
 
 
 class CannedResponseAdmin(ModelAdmin):


### PR DESCRIPTION
fixes #158 

- adds a view live column to comments listing
- it will open the associated page in a new tab