### PR TITLE
updates export filename for users, comments, quiz, poll, and survey

### DIFF
--- a/comments/wagtail_hooks.py
+++ b/comments/wagtail_hooks.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.utils import timezone
 from django.utils.html import format_html
 from django_comments_xtd.models import XtdComment
@@ -61,7 +62,7 @@ class XtdCommentAdmin(ModelAdmin):
 
     @property
     def export_filename(self):
-        return f'comments_{timezone.now().strftime("%Y-%m-%dT%H%M%S")}'
+        return f'comments_{timezone.now().strftime(settings.EXPORT_FILENAME_TIMESTAMP_FORMAT)}'
 
 
 class CannedResponseAdmin(ModelAdmin):

--- a/comments/wagtail_hooks.py
+++ b/comments/wagtail_hooks.py
@@ -1,3 +1,4 @@
+from django.utils import timezone
 from django.utils.html import format_html
 from django_comments_xtd.models import XtdComment
 from wagtail.contrib.modeladmin.options import ModelAdminGroup, ModelAdmin, modeladmin_register
@@ -47,6 +48,20 @@ class XtdCommentAdmin(ModelAdmin):
 
     def num_flags(self, obj):
         return obj.flags.count()
+
+    def view_live(self, obj):
+        content_object = obj.content_object
+        url = getattr(content_object, 'url', None)
+        if url:
+            return f'<a href="{url}" target="_blank">{content_object.title}</a>'
+
+        return 'N/A'
+
+    view_live.allow_tags = True
+
+    @property
+    def export_filename(self):
+        return f'comments_{timezone.now().strftime("%Y-%m-%dT%H%M%S")}'
 
 
 class CannedResponseAdmin(ModelAdmin):

--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -381,3 +381,5 @@ SEARCH_RESULTS_PER_PAGE = 10
 COMMIT_HASH = os.getenv('COMMIT_HASH')
 
 from .profanity_settings import *
+
+EXPORT_FILENAME_TIMESTAMP_FORMAT = '%Y-%m-%dT%H%M%S'

--- a/iogt_users/wagtail_hooks.py
+++ b/iogt_users/wagtail_hooks.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
@@ -28,7 +29,7 @@ class UsersExportAdmin(ModelAdmin):
 
     @property
     def export_filename(self):
-        return f'users_{timezone.now().strftime("%Y-%m-%dT%H%M%S")}'
+        return f'users_{timezone.now().strftime(settings.EXPORT_FILENAME_TIMESTAMP_FORMAT)}'
 
 
 modeladmin_register(UsersExportAdmin)

--- a/iogt_users/wagtail_hooks.py
+++ b/iogt_users/wagtail_hooks.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 
 from home.models import SiteSettings
@@ -24,6 +25,10 @@ class UsersExportAdmin(ModelAdmin):
         user_submission = obj.usersubmission_set.filter(
             page__pk=site_settings.registration_survey.pk).order_by('-submit_time').first()
         return user_submission.form_data if user_submission else ''
+
+    @property
+    def export_filename(self):
+        return f'users_{timezone.now().strftime("%Y-%m-%dT%H%M%S")}'
 
 
 modeladmin_register(UsersExportAdmin)

--- a/questionnaires/models.py
+++ b/questionnaires/models.py
@@ -2,6 +2,7 @@ import json
 
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
+from django.utils import timezone
 from django.utils.functional import cached_property
 
 from django.core.paginator import EmptyPage, PageNotAnInteger
@@ -28,6 +29,8 @@ from wagtail.images.blocks import ImageChooserBlock
 from questionnaires.blocks import SkipState, SkipLogicBlock
 from questionnaires.forms import CustomFormBuilder, SurveyForm, QuizForm
 from questionnaires.utils import SkipLogicPaginator, FormHelper
+from questionnaires.views import CustomSubmissionsListView
+
 
 FORM_FIELD_CHOICES = (
     ('checkbox', _('Checkbox')),
@@ -197,6 +200,9 @@ class QuestionnairePage(Page, PageUtilsMixin):
             page=self,
             user=None if user.is_anonymous else user,
         )
+
+    def get_submissions_list_view_class(self):
+        return CustomSubmissionsListView
 
     class Meta:
         abstract = True

--- a/questionnaires/models.py
+++ b/questionnaires/models.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.utils import timezone
@@ -203,6 +204,13 @@ class QuestionnairePage(Page, PageUtilsMixin):
 
     def get_submissions_list_view_class(self):
         return CustomSubmissionsListView
+
+    def get_export_filename(self):
+        object_type = self.__class__.__name__.lower()
+        title = self.title
+        timestamp = timezone.now().strftime(settings.EXPORT_FILENAME_TIMESTAMP_FORMAT)
+
+        return f'{object_type}-{title}_{timestamp}'
 
     class Meta:
         abstract = True

--- a/questionnaires/views.py
+++ b/questionnaires/views.py
@@ -1,0 +1,17 @@
+from django.utils import timezone
+from wagtail.contrib.forms.views import SubmissionsListView
+
+
+class CustomSubmissionsListView(SubmissionsListView):
+    def get_filename(self):
+        from questionnaires.models import Poll, Quiz, Survey
+
+        object_type = ''
+        if isinstance(self.form_page, Poll):
+            object_type = 'poll'
+        elif isinstance(self.form_page, Quiz):
+            object_type = 'quiz'
+        elif isinstance(self.form_page, Survey):
+            object_type = 'survey'
+
+        return f'{object_type}-{self.form_page.title}_{timezone.now().strftime("%Y-%m-%dT%H%M%S")}'

--- a/questionnaires/views.py
+++ b/questionnaires/views.py
@@ -1,17 +1,6 @@
-from django.utils import timezone
 from wagtail.contrib.forms.views import SubmissionsListView
 
 
 class CustomSubmissionsListView(SubmissionsListView):
     def get_filename(self):
-        from questionnaires.models import Poll, Quiz, Survey
-
-        object_type = ''
-        if isinstance(self.form_page, Poll):
-            object_type = 'poll'
-        elif isinstance(self.form_page, Quiz):
-            object_type = 'quiz'
-        elif isinstance(self.form_page, Survey):
-            object_type = 'survey'
-
-        return f'{object_type}-{self.form_page.title}_{timezone.now().strftime("%Y-%m-%dT%H%M%S")}'
+        return self.form_page.get_export_filename()


### PR DESCRIPTION
fixes #161 

- updates export filename for comments to `comments_timestamp`
- updates export filename for users to `user_timestamp`
- updates export filename for poll to `poll-poll_title_timestamp`
- updates export filename for survey to `survey-survey_title_timestamp`
- updates export filename for quiz to `quiz-quiz_title_timestamp`
