### PR TITLE
updates wagtail markdown version and add additional blocks

### DIFF
--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -383,3 +383,7 @@ COMMIT_HASH = os.getenv('COMMIT_HASH')
 from .profanity_settings import *
 
 EXPORT_FILENAME_TIMESTAMP_FORMAT = '%Y-%m-%dT%H%M%S'
+
+WAGTAILMARKDOWN = {
+    'allowed_tags': ['i', 'b'],
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 django-extensions
 elasticsearch>=7.0.0,<8.0.0
 psycopg2==2.8.*
-wagtail-markdown==0.6
+wagtail-markdown==0.7.0
 wagtail==2.11.*
 wagtailmedia==0.7.0
 wagtailmenus~=3.0


### PR DESCRIPTION
fixes #234 

- updates wagtailmarkdown version to support additional HTML tags
- add additional HTML tags
- now supported tags 
  - "p", "div", "span", "h1", "h2", "h3", "h4", "h5", "h6", "tt", "pre", "em", "strong", "ul", "sup", "li", "dl", "dd", "dt", "code", "img", "a", "table", "tr", "th", "td", "tbody", "caption", "colgroup", "thead", "foot", "blockquote", "ol", "hr", "b", "b", "i"
