### PR TITLE
handles registration survey response in user export for multi-lang

### DIFF
--- a/iogt_users/wagtail_hooks.py
+++ b/iogt_users/wagtail_hooks.py
@@ -22,11 +22,11 @@ class UsersExportAdmin(ModelAdmin):
     menu_order = 601
 
     def registration_survey_response(self, obj):
-        site_settings = SiteSettings.get_for_default_site()
+        registration_survey = SiteSettings.get_for_default_site().registration_survey
         user_submission = None
-        if site_settings.registration_survey:
-            user_submission = obj.usersubmission_set.filter(
-                page__pk=site_settings.registration_survey.pk).order_by('-submit_time').first()
+        if registration_survey:
+            ids = [registration_survey.id] + list(registration_survey.get_translations().values_list('id', flat=True))
+            user_submission = obj.usersubmission_set.filter(page__pk__in=ids).order_by('submit_time').first()
 
         return user_submission.form_data if user_submission else ''
 

--- a/iogt_users/wagtail_hooks.py
+++ b/iogt_users/wagtail_hooks.py
@@ -25,7 +25,7 @@ class UsersExportAdmin(ModelAdmin):
         registration_survey = SiteSettings.get_for_default_site().registration_survey
         user_submission = None
         if registration_survey:
-            ids = [registration_survey.id] + list(registration_survey.get_translations().values_list('id', flat=True))
+            ids = registration_survey.get_translations(inclusive=True).values_list('id', flat=True)
             user_submission = obj.usersubmission_set.filter(page__pk__in=ids).order_by('submit_time').first()
 
         return user_submission.form_data if user_submission else ''


### PR DESCRIPTION
fixes #182 

- handles registration survey response in user export for multi-lang
- export will include the very first submission