### PR TITLE
help text rendering for input fields

### DIFF
--- a/questionnaires/templates/questionnaires/tags/field_description.html
+++ b/questionnaires/templates/questionnaires/tags/field_description.html
@@ -2,7 +2,9 @@
 
 <p class="quest-item__step-desc">
     <span>
-        {% if not field.field.required %}
+        {% if field.help_text %}
+          {% translate field.help_text %}
+        {% elif not field.field.required %}
             {% translate "Optional" %}
         {% elif field.widget_type == "radioselect" or field.widget_type == "select" %}
             {% translate "Select one" %}


### PR DESCRIPTION
fixes #350 

- if help text is given for input fields then only render that otherwise use existing logic