### PR TITLE
uses or logic for radio field in quiz eval

### DIFF
--- a/questionnaires/models.py
+++ b/questionnaires/models.py
@@ -737,7 +737,11 @@ class Quiz(QuestionnairePage, AbstractForm):
                 if type(answer) != list:
                     answer = [str(answer)]
 
-                is_correct = set(answer) == set(correct_answer)
+                if field.field_type == 'radio':
+                    is_correct = set(answer).issubset(set(correct_answer))
+                else:
+                    is_correct = set(answer) == set(correct_answer)
+
                 if is_correct:
                     total_correct += 1
                 total += 1


### PR DESCRIPTION
fixes #391 

- uses OR logic for radio field in quiz evaluation
- user will score a point if the user chooses one of the correct answers
