### PR TITLE
Fix locale mapping

### DIFF
--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -246,8 +246,7 @@ class Command(BaseCommand):
         else:
             for row in section_page_translations:
                 section = self.v1_to_v2_page_map.get(self.page_translation_map[row['page_ptr_id']])
-                locale, __ = Locale.objects.get_or_create(language_code=row['locale'])
-                locale = self._get_iso_locale(locale)
+                locale, __ = Locale.objects.get_or_create(language_code=self._get_iso_locale(row['locale']))
 
                 self.translate_page(locale=locale, page=section)
 
@@ -303,8 +302,7 @@ class Command(BaseCommand):
         else:
             for row in article_page_translations:
                 article = self.v1_to_v2_page_map.get(self.page_translation_map[row['page_ptr_id']])
-                locale, __ = Locale.objects.get_or_create(language_code=row['locale'])
-                locale = self._get_iso_locale(locale)
+                locale, __ = Locale.objects.get_or_create(language_code=self._get_iso_locale(row['locale']))
 
                 self.translate_page(locale=locale, page=article)
 
@@ -372,8 +370,7 @@ class Command(BaseCommand):
         else:
             for row in banner_page_translations:
                 banner = self.v1_to_v2_page_map.get(self.page_translation_map[row['page_ptr_id']])
-                locale, __ = Locale.objects.get_or_create(language_code=row['locale'])
-                locale = self._get_iso_locale(locale)
+                locale, __ = Locale.objects.get_or_create(language_code=self._get_iso_locale(row['locale']))
 
                 try:
                     self.translate_page(locale=locale, page=banner)
@@ -435,8 +432,7 @@ class Command(BaseCommand):
         else:
             for row in footer_page_translations:
                 footer = self.v1_to_v2_page_map.get(self.page_translation_map[row['page_ptr_id']])
-                locale, __ = Locale.objects.get_or_create(language_code=row['locale'])
-                locale = self._get_iso_locale(locale)
+                locale, __ = Locale.objects.get_or_create(language_code=self._get_iso_locale(row['locale']))
 
                 self.translate_page(locale=locale, page=footer)
 
@@ -529,8 +525,7 @@ class Command(BaseCommand):
         else:
             for row in poll_page_translations:
                 poll = self.v1_to_v2_page_map.get(self.page_translation_map[row['page_ptr_id']])
-                locale, __ = Locale.objects.get_or_create(language_code=row['locale'])
-                locale = self._get_iso_locale(locale)
+                locale, __ = Locale.objects.get_or_create(language_code=self._get_iso_locale(row['locale']))
 
                 try:
                     self.translate_page(locale=locale, page=poll)
@@ -654,8 +649,7 @@ class Command(BaseCommand):
         else:
             for row in survey_page_translations:
                 survey = self.v1_to_v2_page_map.get(self.page_translation_map[row['page_ptr_id']])
-                locale, __ = Locale.objects.get_or_create(language_code=row['locale'])
-                locale = self._get_iso_locale(locale)
+                locale, __ = Locale.objects.get_or_create(language_code=self._get_iso_locale(row['locale']))
 
                 try:
                     self.translate_page(locale=locale, page=survey)

--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -718,7 +718,7 @@ class Command(BaseCommand):
             if block['type'] == 'paragraph':
                 v2_survey_description.append(block)
             elif block['type'] == 'image':
-                image = self.image_map.get(block.value['image'])
+                image = self.image_map.get(block['value'])
                 if image:
                     v2_survey_description.append({'type': 'image', 'value': image.id})
         return json.dumps(v2_survey_description)


### PR DESCRIPTION
Fix: Migrating DBs with ch/sho locales would create these in our DB, but there they are invalid (renamed to ny/sn) and crash the page
Fix: Migration would crash for surveys with images.