### PR TITLE
fixes left menu misplaced issue on chat ui

### DIFF
--- a/messaging/templates/messaging/thread_detail.html
+++ b/messaging/templates/messaging/thread_detail.html
@@ -53,7 +53,6 @@
                     </div>
                 </form>
             </div>
-            </div>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
fixes #507 

- fixes left menu misplaced issue on thread details page
