### PR TITLE
removes google fonts stylesheet as not being used

### DIFF
--- a/iogt/templates/base.html
+++ b/iogt/templates/base.html
@@ -36,7 +36,6 @@
     <link rel="apple-touch-icon" href="{% static 'icons/unicef-logo.png' %}">
 
         {# Global stylesheets #}
-        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <link rel="stylesheet" type="text/css" href="{% static 'css/iogt.css' %}">
         <link rel="stylesheet" type="text/css" href="{% static 'css/chatbot.css' %}">
         <link rel="stylesheet" type="text/css" href="{% static 'css/header/header.css' %}">


### PR DESCRIPTION
fixes #581 

- removes google material icons stylesheet as not being used anywhere in the project
