### PR TITLE
Implement 'randomize options' for polls

### DIFF
--- a/questionnaires/forms.py
+++ b/questionnaires/forms.py
@@ -1,3 +1,4 @@
+import random
 from collections import defaultdict
 
 from django.core.exceptions import ValidationError
@@ -34,29 +35,28 @@ class CustomFormBuilder(FormBuilder):
         return forms.IntegerField(**options)
 
     def create_dropdown_field(self, field, options):
-        options['choices'] = map(
-            lambda x: (x.strip(), x.strip()),
-            field.choices.split('|')
-        )
+        options['choices'] = [(x.strip(), x.strip()) for x in field.choices.split('|')]
+        if getattr(field.page, 'randomise_options', False):
+            random.shuffle(options['choices'])
         return forms.ChoiceField(**options)
 
     def create_multiselect_field(self, field, options):
-        options['choices'] = map(
-            lambda x: (x.strip(), x.strip()),
-            field.choices.split('|')
-        )
+        options['choices'] = [(x.strip(), x.strip()) for x in field.choices.split('|')]
+        if getattr(field.page, 'randomise_options', False):
+            random.shuffle(options['choices'])
         return forms.MultipleChoiceField(**options)
 
     def create_radio_field(self, field, options):
-        options['choices'] = map(
-            lambda x: (x.strip(), x.strip()),
-            field.choices.split('|')
-        )
+        options['choices'] = [(x.strip(), x.strip()) for x in field.choices.split('|')]
+        if getattr(field.page, 'randomise_options', False):
+            random.shuffle(options['choices'])
         return forms.ChoiceField(widget=forms.RadioSelect, **options)
 
     def create_checkboxes_field(self, field, options):
         options['choices'] = [(x.strip(), x.strip()) for x in field.choices.split('|')]
         options['initial'] = [x.strip() for x in field.default_value.split('|')]
+        if getattr(field.page, 'randomise_options', False):
+            random.shuffle(options['choices'])
         return forms.MultipleChoiceField(
             widget=forms.CheckboxSelectMultiple, **options
         )


### PR DESCRIPTION
Closes #596 
- Shuffle choices when creating fields if `randomise_options` is enabled on a poll

![Screenshot from 2021-10-25 13-25-14](https://user-images.githubusercontent.com/92599211/138742659-2378189e-b942-4e37-ac7c-0ebf85daa67f.png)
