### PR TITLE
Fix image clipping on section pages at mobile size

### DIFF
--- a/home/static/css/section/section.css
+++ b/home/static/css/section/section.css
@@ -77,7 +77,6 @@
 }
 
 .overlay-holder {
-  overflow: hidden;
   position: relative;
 }
 


### PR DESCRIPTION
Fixes #707 

Small style tweak fixes this on both related articles and sub sections:

![image](https://user-images.githubusercontent.com/92599211/139720676-1cd04e0c-88ff-4c17-97bf-ba6a87afe2c0.png)

I confirmed that the "completed" overlay still renders properly, which seems to be the primary function of the style I modified:


![image](https://user-images.githubusercontent.com/92599211/139720930-2e47b8a6-49da-4b8f-916e-c842d8a78d08.png)

I did have one question -- There exists a sass file section.scss containing section styles, but it appears that recent changes only update the .css version, so that's what I did here. Is this correct?
