### PR TITLE
Prevent new user registrations that differ only in capitalization

### DIFF
--- a/iogt_users/forms.py
+++ b/iogt_users/forms.py
@@ -2,6 +2,7 @@ from allauth.account.forms import SignupForm, ChangePasswordForm as BaseChangePa
 from allauth.utils import set_form_field_order
 from django import forms
 from django.contrib.auth.forms import UserCreationForm, UserChangeForm
+from django.core.exceptions import ValidationError
 from django.forms import TextInput, Field
 from django.utils.translation import gettext_lazy as _
 from wagtail.users.forms import UserEditForm as WagtailUserEditForm, \
@@ -59,6 +60,12 @@ class WagtailAdminUserCreateForm(WagtailUserCreationForm):
     first_name = forms.CharField(required=False, label='First Name')
     last_name = forms.CharField(required=False, label='Last Name')
     terms_accepted = forms.BooleanField(label=_('I accept the terms & conditions'))
+
+    def clean_username(self):
+        username = self.cleaned_data['username']
+        if User.objects.filter(username__iexact=username):
+            raise ValidationError(_('A user with that username already exists.'))
+        return username
 
 
 class WagtailAdminUserEditForm(WagtailUserEditForm):


### PR DESCRIPTION
Closes #654 

Prior to making changes for this I noted that from the iogt app, a user can NOT register a new user with a username that differs only in terms of case. For example, I created a user foobar:

![image](https://user-images.githubusercontent.com/92599211/139865016-105ceb01-8e1b-4724-b928-94ac3a3bb8da.png)
---
![image](https://user-images.githubusercontent.com/92599211/139865055-437c13ab-d353-46f8-a5b5-a85f69166994.png)
---
I then attempted to create a user FoObAr, and was refused with the following validation message:

![image](https://user-images.githubusercontent.com/92599211/139865149-df1723f0-a029-4d13-b9c1-8116ab6a22c6.png)
---
But, a user CAN do it from the Wagtail admin interface. This change adds validation to `WagtailAdminUserCreateForm` to mirror the above behavior:

![image](https://user-images.githubusercontent.com/92599211/139865491-94f0fbe2-9ec4-4fbc-9d9a-12d64f8acf71.png)
