### PR TITLE
Fix scaling factor when calling cairosvg.svg2png

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -984,7 +984,7 @@ class SVGToPNGMap(models.Model):
         try:
             obj = cls.objects.get(svg_path=svg_path, fill_color=fill_color, stroke_color=stroke_color)
         except cls.DoesNotExist:
-            png_image = convert_svg_to_png_bytes(svg_path, fill_color=fill_color, stroke_color=stroke_color, scale=10)
+            png_image = convert_svg_to_png_bytes(svg_path, fill_color=fill_color, stroke_color=stroke_color, width=32)
             obj = cls.objects.create(
                 svg_path=svg_path, fill_color=fill_color, stroke_color=stroke_color, png_image_file=png_image)
         return obj.png_image_file

--- a/home/utils/image.py
+++ b/home/utils/image.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup
 from django.core.files.base import ContentFile
 
 
-def convert_svg_to_png_bytes(svg_file_path, fill_color=None, stroke_color=None, scale=100):
+def convert_svg_to_png_bytes(svg_file_path, fill_color=None, stroke_color=None, width=32):
     with open(svg_file_path, 'r', encoding='utf-8') as f:
         soup = BeautifulSoup(f, 'lxml')
         elements_to_fill = soup.find_all('path')
@@ -19,5 +19,5 @@ def convert_svg_to_png_bytes(svg_file_path, fill_color=None, stroke_color=None, 
     parsed_soup = str(soup.body.next)
     parsed_soup = parsed_soup.replace('viewbox', 'viewBox')
 
-    file_bytes = cairosvg.svg2png(bytestring=parsed_soup, scale=scale)
+    file_bytes = cairosvg.svg2png(bytestring=parsed_soup, output_width=width)
     return ContentFile(file_bytes, 'svg-to-png.png')


### PR DESCRIPTION
Fixes #719 

In `SVGToPNGMap.get_png_image()`, a scaling factor of 10 is being passed to `convert_svg_to_png_bytes()`, resulting in a 10x scaling of the resulting png image when that scale value is passed to `cairosvg.svg2png()`. Additionally, the default scale value in `convert_svg_to_png_bytes()` is 100, which would result in a 100x scaling. Setting this to 1 results in a png that is the same width and height as the source svg.

As an example, I downloaded a [freely available svg file](https://www.svgrepo.com/svg/365021/aperture-thin) which has a defined width and height of 256px. I uploaded it into the iogt app before and after making this change. The below screenshot shows that before making this change, the resulting png is scaled 10x, or 2560x2560 px (195 kB):

![image](https://user-images.githubusercontent.com/92599211/139879027-2192c6b5-7267-4139-926c-3500a9e7878d.png)
---
Whereas after this change, the resulting png is the original size of 256x256 px (14.3 kB):

![image](https://user-images.githubusercontent.com/92599211/139879243-535501f2-a6ee-4eea-9b77-462e544fb116.png)
---
Note: I believe after merging this, any existing SVGs will need to be re-uploaded to be resized properly.