### PR TITLE
anonymous username for comment irrespective of case

### DIFF
--- a/comments/forms.py
+++ b/comments/forms.py
@@ -23,7 +23,7 @@ class CommentForm(BaseCommentForm):
 
         if self.cleaned_data['post_anonymously']:
             data['user_email'] = ''
-            data['user_name'] = 'anonymous'
+            data['user_name'] = 'Anonymous'
         return data
 
 

--- a/comments/templates/comment_reply.html
+++ b/comments/templates/comment_reply.html
@@ -14,7 +14,7 @@
     </header>
     <div class="row nice-padding">
         <h2>Comment </h2>{{ comment.comment }}
-        <h4>User</h4>{% if comment.user_name == 'anonymous' %}Anonymous{% else %}{{ comment.user.get_display_name }}{% endif %}
+        <h4>User</h4>{% if comment.user_name|lower == 'anonymous' %}Anonymous{% else %}{{ comment.user.get_display_name }}{% endif %}
     </div>
     <hr/>
     <div class="row nice-padding">

--- a/comments/templates/django_comments_xtd/comment_tree.html
+++ b/comments/templates/django_comments_xtd/comment_tree.html
@@ -14,7 +14,7 @@
             <div>
                 <div class='individual-comment__data'>
                     <span>
-                        {% if item.comment.user_name == 'anonymous' %}
+                        {% if item.comment.user_name|lower == 'anonymous' %}
                             <p>A</p>
                             <p>{% translate "Anonymous" %}</p>
                         {% else %}
@@ -28,7 +28,7 @@
                     <a href="{{ item.comment.url }}" target="_new">
                 {% endif %}
                 {% if item.comment.url %}</a>{% endif %}
-                {% if item.comment.user_name != 'anonymous' and item.comment.user and item.comment.user|has_permission:"django_comments_xtd.can_moderate" %}
+                {% if item.comment.user_name|lower != 'anonymous' and item.comment.user and item.comment.user|has_permission:"django_comments_xtd.can_moderate" %}
                     &nbsp;<span class='individual-comment__moderator'>{% translate "moderator" %}</span>{% endif %}
                 &nbsp;&nbsp;
                 <span>

--- a/comments/templates/django_comments_xtd/reply.html
+++ b/comments/templates/django_comments_xtd/reply.html
@@ -18,7 +18,7 @@
         <div class="media-body">
           <div class="comment pb-3">
             <h6 class="mb-1 small">
-              {{ comment.submit_date|naturaltime }}&nbsp;-&nbsp;{% if comment.user_name == 'anonymous' %}Anonymous{% else %}{{ comment.user.get_display_name }}{% endif %}
+              {{ comment.submit_date|naturaltime }}&nbsp;-&nbsp;{% if comment.user_name|lower == 'anonymous' %}Anonymous{% else %}{{ comment.user.get_display_name }}{% endif %}
             </h6>
             <p>{{ comment.comment }}</p>
           </div>


### PR DESCRIPTION
fixes #834 

- updates rendering check for anonymous user_name for comment 
- 'anonymous' and 'Anonymous' will be treated as same
- V2 will save capitalized 'Anonymous'
