### PR TITLE
adds health check package

### DIFF
--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -67,6 +67,11 @@ INSTALLED_APPS = [
     'rest_framework',
     'sass_processor',
     'translation_manager',
+    'health_check',
+    'health_check.db',
+    'health_check.cache',
+    'health_check.storage',
+    'health_check.contrib.migrations',
 
     'django.contrib.admin',
     'django.contrib.auth',

--- a/iogt/urls.py
+++ b/iogt/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     path("manifest.webmanifest", get_manifest, name="manifest"),
     path('comments/', include('comments.urls')),
     *i18n_patterns(path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog')),
+    path('ht/', include('health_check.urls')),
 ]
 
 if settings.DEBUG:

--- a/iogt/urls.py
+++ b/iogt/urls.py
@@ -36,7 +36,7 @@ urlpatterns = [
     path("manifest.webmanifest", get_manifest, name="manifest"),
     path('comments/', include('comments.urls')),
     *i18n_patterns(path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog')),
-    path('ht/', include('health_check.urls')),
+    path('health-check/', include('health_check.urls')),
 ]
 
 if settings.DEBUG:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ wagtailmedia==0.7.0
 wagtailmenus~=3.0
 wagtailsvg==0.0.14
 whitenoise==5.2.*
+django-health-check==3.16.5


### PR DESCRIPTION
fixes #890 

- adds django-health-check package with db, cache, storage, migration apps
- register url as `/health-check/` 

sample request:
`curl -H "Accept: application/json" http://localhost:8000/health-check/`
sample response:
`{"Cache backend: default": "working", "DatabaseBackend": "working", "DefaultFileStorageHealthCheck": "working", "MigrationsHealthCheck": "working"}`