### PR TITLE
create locale details in content migration

### DIFF
--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -438,7 +438,14 @@ class Command(BaseCommand):
             )
 
         if should_deactivate_en_locale:
-            models.LocaleDetail.objects.filter(locale__language_code='en').update(is_active=False)
+            locale, __ = Locale.objects.get_or_create(language_code='en')
+            models.LocaleDetail.objects.update_or_create(
+                locale=locale,
+                defaults={
+                    'is_active': False,
+                    'is_main_language': False,
+                }
+            )
         cur.close()
 
     def find_content_type_id(self, app_label, model):

--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -219,6 +219,13 @@ class Command(BaseCommand):
             raise Exception('Could not find a main language in v1 DB')
 
         locale = Locale.objects.get(language_code=self._get_iso_locale(language['locale']))
+        models.LocaleDetail.objects.update_or_create(
+            locale=locale,
+            defaults={
+                'is_active': True,
+                'is_main_language': True,
+            }
+        )
 
         home = models.HomePage(
             title=main['title'],
@@ -417,7 +424,14 @@ class Command(BaseCommand):
               f'from core_sitelanguage'
         cur = self.db_query(sql)
         for row in cur:
-            Locale.objects.get_or_create(language_code=self._get_iso_locale(row['locale']))
+            locale, __ = Locale.objects.get_or_create(language_code=self._get_iso_locale(row['locale']))
+            models.LocaleDetail.objects.get_or_create(
+                locale=locale,
+                defaults={
+                    'is_active': True,
+                    'is_main_language': False,
+                }
+            )
         cur.close()
 
     def find_content_type_id(self, app_label, model):


### PR DESCRIPTION
fixes #968 

- create locale details in content migration
- all locale details will be active by default
- main language will be set from v1 db