### PR TITLE
adds accessibility text for quiz answers

### DIFF
--- a/questionnaires/templates/quizzes/quiz_landing.html
+++ b/questionnaires/templates/quizzes/quiz_landing.html
@@ -104,11 +104,11 @@
                             {% if field|length > 1 %}
                                 {% for field_option in field %}
                                     <div class="quest-item__content" tabindex="0">
-                                        <label class="cust-check cust-check--2 quest-item__input
-                                                {% get_answer_rendering_class field field_option fields_info %}"
+                                        {% get_answer_options field field_option fields_info as answer_options %}
+                                        <label class="cust-check cust-check--2 quest-item__input {{ answer_options.class }}"
                                                tabindex="0">
                                             <div class="cust-check__title">
-                                                <span class="cust-check__check"></span>
+                                                <span class="cust-check__check" aria-label="{{ answer_options.aria_label }}"></span>
                                                 <span>{{ field_option.choice_label }}</span>
                                             </div>
                                         </label>

--- a/questionnaires/templatetags/questionnaires_tags.py
+++ b/questionnaires/templatetags/questionnaires_tags.py
@@ -161,18 +161,30 @@ def render_questionnaire_wrapper(context, page, direct_display, background_color
 
 
 @register.simple_tag
-def get_answer_rendering_class(field, field_option, fields_info):
+def get_answer_options(field, field_option, fields_info):
     label = field_option.choice_label
     correct_answers = fields_info.get(field.name, {}).get('correct_answer_list', [])
     is_selected = field_option.data.get('selected', False)
     rv = ''
     if is_selected and label in correct_answers:
-        rv = 'success'
+        rv = {
+            'class': 'success',
+            'aria_label': 'Checkbox with tick, indicating correct and selected',
+        }
     elif is_selected and label not in correct_answers:
-        rv = 'error'
+        rv = {
+            'class': 'error',
+            'aria_label': 'Checkbox with X, indicating incorrect and selected',
+        }
     elif not is_selected and label in correct_answers:
-        rv = 'clear-tick'
+        rv = {
+            'class': 'clear-tick',
+            'aria_label': 'Checkbox with tick, indicating correct but not selected',
+        }
     elif not is_selected and label not in correct_answers:
-        rv = 'clear-cross'
+        rv = {
+            'class': 'clear-cross',
+            'aria_label': 'Checkbox with X, indicating incorrect and not selected',
+        }
 
     return rv


### PR DESCRIPTION
fixes #338 

- used [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) for accessibility as span tag doesn't have any alt text option