### PR TITLE
handles case of no survey key in skip logic

### DIFF
--- a/questionnaires/management/commands/fix_survey_skip_logic.py
+++ b/questionnaires/management/commands/fix_survey_skip_logic.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
             if survey_form_field.skip_logic:
                 skip_logics = survey_form_field.skip_logic.stream_data
                 for skip_logic in skip_logics:
-                    skip_logic.get('value', {}).pop('survey')
+                    skip_logic.get('value', {}).pop('survey', None)
 
         SurveyFormField.objects.bulk_update(survey_form_fields, fields=['skip_logic'], batch_size=1000)
 


### PR DESCRIPTION
- if survey skip-logic doesn't have a survey key then it shouldn't crash the management command