### PR TITLE
update content migration for large image for top section and comments

### DIFF
--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -1623,8 +1623,9 @@ class Command(BaseCommand):
                             f'featured since: {article.featured_in_homepage_start_date}.'
                         )
 
-                section = models.Section.objects.get(path=k)
-                self.add_section_as_featured_content_in_home_page(section)
+                section = models.Section.objects.filter(path=k).first()
+                if section:
+                    self.add_section_as_featured_content_in_home_page(section)
 
         locale_cur.close()
 

--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -541,6 +541,10 @@ class Command(BaseCommand):
                             f'title: {translated_section.title}. URL: {translated_section.full_url}. '
                             f'Admin URL: {self.get_admin_url(translated_section.id)}.'
                         )
+                    self.post_migration_report_messages['disabled_larger_image_for_top_page_in_list_as_in_v1'].append(
+                        f'title: {translated_section.title}. URL: {translated_section.full_url}. '
+                        f'Admin URL: {self.get_admin_url(translated_section.id)}.'
+                    )
 
                 self.stdout.write(f"Translated section, title={row['title']}")
         cur.close()
@@ -596,6 +600,10 @@ class Command(BaseCommand):
                 f'title: {section.title}. URL: {section.full_url}. '
                 f'Admin URL: {self.get_admin_url(section.id)}.'
             )
+        self.post_migration_report_messages['disabled_larger_image_for_top_page_in_list_as_in_v1'].append(
+            f'title: {section.title}. URL: {section.full_url}. '
+            f'Admin URL: {self.get_admin_url(section.id)}.'
+        )
         self.stdout.write(f"saved section, title={section.title}")
 
     def add_warning_for_sections_with_description(self, row, section):

--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -545,10 +545,11 @@ class Command(BaseCommand):
                         f'title: {translated_section.title}. URL: {translated_section.full_url}. '
                         f'Admin URL: {self.get_admin_url(translated_section.id)}.'
                     )
-                    self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
-                        f'title: {translated_section.title}. URL: {translated_section.full_url}. '
-                        f'Admin URL: {self.get_admin_url(translated_section.id)}. Original Setting: {commenting_status}.'
-                    )
+                    if commenting_status != CommentStatus.DISABLED:
+                        self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+                            f'title: {translated_section.title}. URL: {translated_section.full_url}. '
+                            f'Admin URL: {self.get_admin_url(translated_section.id)}. Original Setting: {commenting_status}.'
+                        )
 
                 self.stdout.write(f"Translated section, title={row['title']}")
         cur.close()
@@ -608,10 +609,11 @@ class Command(BaseCommand):
             f'title: {section.title}. URL: {section.full_url}. '
             f'Admin URL: {self.get_admin_url(section.id)}.'
         )
-        self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
-            f'title: {section.title}. URL: {section.full_url}. '
-            f'Admin URL: {self.get_admin_url(section.id)}. Original Setting: {commenting_status}.'
-        )
+        if commenting_status != CommentStatus.DISABLED:
+            self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+                f'title: {section.title}. URL: {section.full_url}. '
+                f'Admin URL: {self.get_admin_url(section.id)}. Original Setting: {commenting_status}.'
+            )
         self.stdout.write(f"saved section, title={section.title}")
 
     def add_warning_for_sections_with_description(self, row, section):
@@ -692,10 +694,11 @@ class Command(BaseCommand):
                         row['page_ptr_id']: translated_article
                     })
 
-                    self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
-                        f'title: {translated_article.title}. URL: {translated_article.full_url}. '
-                        f'Admin URL: {self.get_admin_url(translated_article.id)}. Original Setting: {commenting_status}.'
-                    )
+                    if commenting_status != CommentStatus.DISABLED:
+                        self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+                            f'title: {translated_article.title}. URL: {translated_article.full_url}. '
+                            f'Admin URL: {self.get_admin_url(translated_article.id)}. Original Setting: {commenting_status}.'
+                        )
 
                 self.stdout.write(f"Translated article, title={row['title']}")
         cur.close()
@@ -755,10 +758,11 @@ class Command(BaseCommand):
             self.v1_to_v2_page_map.update({
                 row['page_ptr_id']: article
             })
-            self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
-                f'title: {article.title}. URL: {article.full_url}. '
-                f'Admin URL: {self.get_admin_url(article.id)}. Original Setting: {commenting_status}.'
-            )
+            if commenting_status != CommentStatus.DISABLED:
+                self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+                    f'title: {article.title}. URL: {article.full_url}. '
+                    f'Admin URL: {self.get_admin_url(article.id)}. Original Setting: {commenting_status}.'
+                )
         except Page.DoesNotExist:
             self.post_migration_report_messages['articles'].append(
                 f"Skipping article with missing parent: title={row['title']}"
@@ -1049,10 +1053,11 @@ class Command(BaseCommand):
                         row['page_ptr_id']: translated_footer
                     })
 
-                    self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
-                        f'title: {translated_footer.title}. URL: {translated_footer.full_url}. '
-                        f'Admin URL: {self.get_admin_url(translated_footer.id)}. Original Setting: {commenting_status}.'
-                    )
+                    if commenting_status != CommentStatus.DISABLED:
+                        self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+                            f'title: {translated_footer.title}. URL: {translated_footer.full_url}. '
+                            f'Admin URL: {self.get_admin_url(translated_footer.id)}. Original Setting: {commenting_status}.'
+                        )
 
                 self.stdout.write(f"Translated footer, title={row['title']}")
         cur.close()
@@ -1101,10 +1106,11 @@ class Command(BaseCommand):
             row['page_ptr_id']: footer
         })
 
-        self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
-            f'title: {footer.title}. URL: {footer.full_url}. '
-            f'Admin URL: {self.get_admin_url(footer.id)}. Original Setting: {commenting_status}.'
-        )
+        if commenting_status != CommentStatus.DISABLED:
+            self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+                f'title: {footer.title}. URL: {footer.full_url}. '
+                f'Admin URL: {self.get_admin_url(footer.id)}. Original Setting: {commenting_status}.'
+            )
 
         self.stdout.write(f"saved footer, title={footer.title}")
 

--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -518,7 +518,7 @@ class Command(BaseCommand):
                     translated_section.search_description = row['search_description']
                     translated_section.seo_title = row['seo_title']
                     translated_section.font_color = self.get_color_hex(row['extra_style_hints']) or section.font_color
-                    translated_section.larger_image_for_top_page_in_list_as_in_v1 = True
+                    translated_section.larger_image_for_top_page_in_list_as_in_v1 = False
                     translated_section.commenting_status = commenting_status
                     translated_section.commenting_starts_at = commenting_open_time
                     translated_section.commenting_ends_at = commenting_close_time
@@ -575,7 +575,7 @@ class Command(BaseCommand):
             search_description=row['search_description'],
             seo_title=row['seo_title'],
             font_color=self.get_color_hex(row['extra_style_hints']),
-            larger_image_for_top_page_in_list_as_in_v1=True,
+            larger_image_for_top_page_in_list_as_in_v1=False,
             latest_revision_created_at=row['latest_revision_created_at'],
         )
         section.save()

--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -519,7 +519,7 @@ class Command(BaseCommand):
                     translated_section.seo_title = row['seo_title']
                     translated_section.font_color = self.get_color_hex(row['extra_style_hints']) or section.font_color
                     translated_section.larger_image_for_top_page_in_list_as_in_v1 = False
-                    translated_section.commenting_status = commenting_status
+                    translated_section.commenting_status = CommentStatus.DISABLED
                     translated_section.commenting_starts_at = commenting_open_time
                     translated_section.commenting_ends_at = commenting_close_time
                     translated_section.latest_revision_created_at = row['latest_revision_created_at']
@@ -544,6 +544,10 @@ class Command(BaseCommand):
                     self.post_migration_report_messages['disabled_larger_image_for_top_page_in_list_as_in_v1'].append(
                         f'title: {translated_section.title}. URL: {translated_section.full_url}. '
                         f'Admin URL: {self.get_admin_url(translated_section.id)}.'
+                    )
+                    self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+                        f'title: {translated_section.title}. URL: {translated_section.full_url}. '
+                        f'Admin URL: {self.get_admin_url(translated_section.id)}. Original Setting: {commenting_status}.'
                     )
 
                 self.stdout.write(f"Translated section, title={row['title']}")
@@ -573,7 +577,7 @@ class Command(BaseCommand):
             expire_at=row['expire_at'],
             first_published_at=row['first_published_at'],
             last_published_at=row['last_published_at'],
-            commenting_status=commenting_status,
+            commenting_status=CommentStatus.DISABLED,
             commenting_starts_at=commenting_open_time,
             commenting_ends_at=commenting_close_time,
             search_description=row['search_description'],
@@ -603,6 +607,10 @@ class Command(BaseCommand):
         self.post_migration_report_messages['disabled_larger_image_for_top_page_in_list_as_in_v1'].append(
             f'title: {section.title}. URL: {section.full_url}. '
             f'Admin URL: {self.get_admin_url(section.id)}.'
+        )
+        self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+            f'title: {section.title}. URL: {section.full_url}. '
+            f'Admin URL: {self.get_admin_url(section.id)}. Original Setting: {commenting_status}.'
         )
         self.stdout.write(f"saved section, title={section.title}")
 
@@ -661,7 +669,7 @@ class Command(BaseCommand):
                     translated_article.search_description = row['search_description']
                     translated_article.seo_title = row['seo_title']
                     translated_article.index_page_description = row['subtitle']
-                    translated_article.commenting_status = commenting_status
+                    translated_article.commenting_status = CommentStatus.DISABLED
                     translated_article.commenting_starts_at = commenting_open_time
                     translated_article.commenting_ends_at = commenting_close_time
                     translated_article.latest_revision_created_at = row['latest_revision_created_at']
@@ -683,6 +691,11 @@ class Command(BaseCommand):
                     self.v1_to_v2_page_map.update({
                         row['page_ptr_id']: translated_article
                     })
+
+                    self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+                        f'title: {translated_article.title}. URL: {translated_article.full_url}. '
+                        f'Admin URL: {self.get_admin_url(translated_article.id)}. Original Setting: {commenting_status}.'
+                    )
 
                 self.stdout.write(f"Translated article, title={row['title']}")
         cur.close()
@@ -715,7 +728,7 @@ class Command(BaseCommand):
             expire_at=row['expire_at'],
             first_published_at=row['first_published_at'],
             last_published_at=row['last_published_at'],
-            commenting_status=commenting_status,
+            commenting_status=CommentStatus.DISABLED,
             commenting_starts_at=commenting_open_time,
             commenting_ends_at=commenting_close_time,
             search_description=row['search_description'],
@@ -742,6 +755,10 @@ class Command(BaseCommand):
             self.v1_to_v2_page_map.update({
                 row['page_ptr_id']: article
             })
+            self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+                f'title: {article.title}. URL: {article.full_url}. '
+                f'Admin URL: {self.get_admin_url(article.id)}. Original Setting: {commenting_status}.'
+            )
         except Page.DoesNotExist:
             self.post_migration_report_messages['articles'].append(
                 f"Skipping article with missing parent: title={row['title']}"

--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -1025,7 +1025,7 @@ class Command(BaseCommand):
                     translated_footer.last_published_at = row['last_published_at']
                     translated_footer.search_description = row['search_description']
                     translated_footer.seo_title = row['seo_title']
-                    translated_footer.commenting_status = commenting_status
+                    translated_footer.commenting_status = CommentStatus.DISABLED
                     translated_footer.commenting_starts_at = commenting_open_time
                     translated_footer.commenting_ends_at = commenting_close_time
                     translated_footer.latest_revision_created_at = row['latest_revision_created_at']
@@ -1048,6 +1048,11 @@ class Command(BaseCommand):
                     self.v1_to_v2_page_map.update({
                         row['page_ptr_id']: translated_footer
                     })
+
+                    self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+                        f'title: {translated_footer.title}. URL: {translated_footer.full_url}. '
+                        f'Admin URL: {self.get_admin_url(translated_footer.id)}. Original Setting: {commenting_status}.'
+                    )
 
                 self.stdout.write(f"Translated footer, title={row['title']}")
         cur.close()
@@ -1072,7 +1077,7 @@ class Command(BaseCommand):
             last_published_at=row['last_published_at'],
             search_description=row['search_description'],
             seo_title=row['seo_title'],
-            commenting_status=commenting_status,
+            commenting_status=CommentStatus.DISABLED,
             commenting_starts_at=commenting_open_time,
             commenting_ends_at=commenting_close_time,
             latest_revision_created_at=row['latest_revision_created_at'],
@@ -1095,6 +1100,12 @@ class Command(BaseCommand):
         self.v1_to_v2_page_map.update({
             row['page_ptr_id']: footer
         })
+
+        self.post_migration_report_messages['disabled_comments_for_pages_which_has_other_settings'].append(
+            f'title: {footer.title}. URL: {footer.full_url}. '
+            f'Admin URL: {self.get_admin_url(footer.id)}. Original Setting: {commenting_status}.'
+        )
+
         self.stdout.write(f"saved footer, title={footer.title}")
 
     def load_page_translation_map(self):


### PR DESCRIPTION
Closes #1220 

- sets larger image for the top section to false and adds message in the post-migration report
- disable comments for all pages (section, article) and adds message in post-migration report