### PR TITLE
updates wagtail localize version to fix edit permission issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ lxml==4.8.*
 psycopg2==2.8.*
 redis~=3.0
 tqdm==4.62.*
-wagtail-localize~=0.9.5
+wagtail-localize==1.1.1
 wagtail-markdown==0.7.0
 wagtail==2.11.*
 wagtailmedia==0.7.0


### PR DESCRIPTION
Closes #1250

- updated wagtail-localize version
- on edit translation segment 403 (permission denied) was raised for the anonymous user
- the reason for user being anonymous was missing authentication classes
- this was fixed in latest version of wagtail-localize
- for reference see [here](https://github.com/wagtail/wagtail-localize/pull/513)