### PR TITLE
fixes block translation to load from translation entity

### DIFF
--- a/iogt/patch.py
+++ b/iogt/patch.py
@@ -50,9 +50,77 @@ def _translate_node_render(self, context):
         return value
 
 
+def _translate_block_node_render(self, context, nested=False):
+    from django.core.cache import cache
+    from django.template import TemplateSyntaxError
+    from django.template.base import render_value_in_context
+    from django.utils import translation
+
+    if self.message_context:
+        message_context = self.message_context.resolve(context)
+    else:
+        message_context = None
+    # Update() works like a push(), so corresponding context.pop() is at
+    # the end of function
+    context.update({var: val.resolve(context) for var, val in self.extra_context.items()})
+    singular, vars = self.render_token_list(self.singular)
+    if self.plural and self.countervar and self.counter:
+        count = self.counter.resolve(context)
+        context[self.countervar] = count
+        plural, plural_vars = self.render_token_list(self.plural)
+        if message_context:
+            result = translation.npgettext(message_context, singular,
+                                           plural, count)
+        else:
+            result = translation.ngettext(singular, plural, count)
+        vars.extend(plural_vars)
+    else:
+        if message_context:
+            result = translation.pgettext(message_context, singular)
+        else:
+            result = translation.gettext(singular)
+    default_value = context.template.engine.string_if_invalid
+
+    try:
+        translation_entry = cache.get(f'{globals_.locale.language_code}_translation_map')[
+            (singular, globals_.locale.language_code)]
+    except (KeyError, TypeError):
+        translation_entry = None
+
+    if translation_entry and translation_entry.translation:
+        result = translation_entry.translation
+
+    def render_value(key):
+        if key in context:
+            val = context[key]
+        else:
+            val = default_value % key if '%s' in default_value else default_value
+        return render_value_in_context(val, context)
+
+    data = {v: render_value(v) for v in vars}
+    context.pop()
+    try:
+        result = result % data
+    except (KeyError, ValueError):
+        if nested:
+            # Either string is malformed, or it's a bug
+            raise TemplateSyntaxError(
+                '%r is unable to format string returned by gettext: %r '
+                'using %r' % (self.tag_name, result, data)
+            )
+        with translation.override(None):
+            result = self.render(context, nested=True)
+    if self.asvar:
+        context[self.asvar] = result
+        return ''
+    else:
+        return result
+
+
 utils.get_dirname_from_lang = get_dirname_from_lang
 utils.get_lang_from_dirname = get_lang_from_dirname
 i18n.TranslateNode.render = _translate_node_render
+i18n.BlockTranslateNode.render = _translate_block_node_render
 
 
 def store_to_db(self, pofile, locale, store_translations=False):


### PR DESCRIPTION
Closes #1249 

- Patched the block translate rendering to try and use database-backed translation first
- if not found in the database then revert to the default behavior