### PR TITLE
Feat/clear user data mgmt cmd

### DIFF
--- a/home/management/commands/clear_user_data.py
+++ b/home/management/commands/clear_user_data.py
@@ -1,0 +1,18 @@
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--user-ids',
+            nargs="+",
+            required=False,
+            type=int,
+            help="IDs for users that wouldn't be cleared"
+        )
+
+    def handle(self, *args, **options):
+        user_ids = options.get('user_ids') or []
+        get_user_model().objects.exclude(pk__in=user_ids).delete()
+        self.stdout.write('User data cleared.')

--- a/home/management/commands/clear_user_data.py
+++ b/home/management/commands/clear_user_data.py
@@ -5,7 +5,7 @@ from django.core.management import BaseCommand
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
-            '--user-ids',
+            '--exclude-user-ids',
             nargs="+",
             required=False,
             type=int,
@@ -13,6 +13,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        user_ids = options.get('user_ids') or []
+        user_ids = options.get('exclude_user_ids') or []
         get_user_model().objects.exclude(pk__in=user_ids).delete()
         self.stdout.write('User data cleared.')

--- a/home/management/commands/clear_user_data.py
+++ b/home/management/commands/clear_user_data.py
@@ -2,6 +2,8 @@ from django.contrib.auth import get_user_model
 from django.core.management import BaseCommand
 from django_comments_xtd.models import XtdComment
 
+from messaging.models import Thread
+
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
@@ -17,4 +19,5 @@ class Command(BaseCommand):
         user_ids = options.get('exclude_user_ids') or []
         get_user_model().objects.exclude(pk__in=user_ids).delete()
         XtdComment.objects.all().delete()
+        Thread.objects.all().delete()
         self.stdout.write('User data cleared.')

--- a/home/management/commands/clear_user_data.py
+++ b/home/management/commands/clear_user_data.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.core.management import BaseCommand
+from django_comments_xtd.models import XtdComment
 
 
 class Command(BaseCommand):
@@ -15,4 +16,5 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         user_ids = options.get('exclude_user_ids') or []
         get_user_model().objects.exclude(pk__in=user_ids).delete()
+        XtdComment.objects.all().delete()
         self.stdout.write('User data cleared.')

--- a/home/management/commands/clear_user_data.py
+++ b/home/management/commands/clear_user_data.py
@@ -3,6 +3,7 @@ from django.core.management import BaseCommand
 from django_comments_xtd.models import XtdComment
 
 from messaging.models import Thread
+from questionnaires.models import UserSubmission
 
 
 class Command(BaseCommand):
@@ -20,4 +21,5 @@ class Command(BaseCommand):
         get_user_model().objects.exclude(pk__in=user_ids).delete()
         XtdComment.objects.all().delete()
         Thread.objects.all().delete()
+        UserSubmission.objects.all().delete()
         self.stdout.write('User data cleared.')

--- a/iogt_content_migration/management/commands/clear_user_data.py
+++ b/iogt_content_migration/management/commands/clear_user_data.py
@@ -1,0 +1,8 @@
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        get_user_model().objects.all().delete()
+        self.stdout.write('User data cleared.')

--- a/iogt_content_migration/management/commands/clear_user_data.py
+++ b/iogt_content_migration/management/commands/clear_user_data.py
@@ -1,8 +1,0 @@
-from django.contrib.auth import get_user_model
-from django.core.management import BaseCommand
-
-
-class Command(BaseCommand):
-    def handle(self, *args, **options):
-        get_user_model().objects.all().delete()
-        self.stdout.write('User data cleared.')


### PR DESCRIPTION
Closes #1252 

- Following data will be cleared by this management command
  - users and users' profiles
  - questionnaires submissions for polls, surveys, and quizzes
  - comments
  - comment flags (comment reporting)
  - chats
- this management command optionally accepts user ids that would be excluded from the clearing process (admins etc)
- ids for excluded users will be retained but their above-mentioned data will be cleared though

usage: 
- `python manage.py clear_user_data`: all users will be cleared
- `python manage.py clear_user_data --exclude-user-ids 1 2 3`: all users will be cleared except users with id 1, 2, and 3
