### PR TITLE
skip translated page with same page id

### DIFF
--- a/iogt_content_migration/management/commands/load_v1_db.py
+++ b/iogt_content_migration/management/commands/load_v1_db.py
@@ -1119,9 +1119,10 @@ class Command(BaseCommand):
               "from core_pagetranslation"
         cur = self.db_query(sql)
         for row in cur:
-            self.page_translation_map.update({
-                row['translated_page_id']: row['page_id'],
-            })
+            if row['translated_page_id'] != row['page_id']:
+                self.page_translation_map.update({
+                    row['translated_page_id']: row['page_id'],
+                })
         cur.close()
         self.stdout.write('Page translation map loaded.')
 


### PR DESCRIPTION
Closes #1258 

- In V1 we get translated pages info from the `core_pagetranslation` table, something like following
  - translated from page id, translated page id
- but in SA backup, some rows in this table contain the same value for both columns
- this is messing up the migration script 
- fix: skip translated page if it has the same page id as translated from page id