### PR TITLE
Investigating set up of Selenium tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 version: '3.5'
-
 services:
 
   django:
@@ -54,5 +53,36 @@ services:
     volumes:
       - /var/lib/redis/data
 
+  selenium-hub:
+    image: selenium/hub:3.141.59-20210929
+    container_name: selenium-hub
+    ports:
+      - "4444:4444"
+
+  chrome:
+    image: selenium/node-chrome-debug:3.141.59-20210929
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      - selenium-hub
+    environment:
+      - HUB_HOST=selenium-hub
+      - HUB_PORT=4444
+    ports:
+      - 5900:5900
+
+  firefox:
+    image: selenium/node-firefox-debug:3.141.59-20210929
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      - selenium-hub
+    environment:
+      - HUB_HOST=selenium-hub
+      - HUB_PORT=4444
+    ports:
+      - 5901:5900
+  
+    
 volumes:
   es-data01:

--- a/iogt/settings/docker_compose_dev.py
+++ b/iogt/settings/docker_compose_dev.py
@@ -14,6 +14,9 @@ WAGTAILSEARCH_BACKENDS = {
     }
 }
 
+# SECURITY WARNING: define the correct hosts in production!
+ALLOWED_HOSTS = ['*']
+
 
 WAGTAILTRANSFER_SECRET_KEY = os.environ.get('WAGTAILTRANSFER_SECRET_KEY')
 WAGTAILTRANSFER_SOURCES = {

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -1,0 +1,77 @@
+import time
+
+from django.test import TestCase
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+
+
+class SeleniumTest(TestCase):
+
+    
+    def setUp(self):
+        self.chrome = webdriver.Remote(
+            command_executor='http://localhost:4444/wd/hub',
+            desired_capabilities=DesiredCapabilities.CHROME
+      )      
+
+        self.firefox = webdriver.Remote(
+            command_executor='http://localhost:4444/wd/hub',
+            desired_capabilities=DesiredCapabilities.FIREFOX
+      )
+       
+    def test_hackernews_search_for_testdrivenio(self):
+        browser = self.chrome
+        browser.get('https://news.ycombinator.com')
+        search_box = browser.find_element_by_name('q')
+        search_box.send_keys('testdriven.io')
+        search_box.send_keys(Keys.RETURN)
+        time.sleep(3)  # simulate long running test
+        self.assertIn('testdriven.io', browser.page_source)
+
+    def test_hackernews_search_for_selenium(self):
+        browser = self.chrome
+        browser.get('https://news.ycombinator.com')
+        search_box = browser.find_element_by_name('q')
+        search_box.send_keys('selenium')
+        search_box.send_keys(Keys.RETURN)
+        time.sleep(3)  # simulate long running test
+        self.assertIn('selenium', browser.page_source)
+
+    def test_hackernews_search_for_testdriven(self):
+        browser = self.firefox
+        browser.get('https://news.ycombinator.com')
+        search_box = browser.find_element_by_name('q')
+        search_box.send_keys('testdriven')
+        search_box.send_keys(Keys.RETURN)
+        time.sleep(3)  # simulate long running test
+        self.assertIn('testdriven', browser.page_source)
+
+    def test_hackernews_search_with_no_results(self):
+        browser = self.firefox
+        browser.get('https://news.ycombinator.com')
+        search_box = browser.find_element_by_name('q')
+        search_box.send_keys('?*^^%')
+        search_box.send_keys(Keys.RETURN)
+        time.sleep(3)  # simulate long running test
+        self.assertNotIn('<em>', browser.page_source)
+
+    def tearDown(self):
+        self.chrome.quit()
+        self.firefox.quit()  # quit vs close?
+
+
+        
+        
+
+    
+
+        
+
+
+    
+
+
+
+
+            


### PR DESCRIPTION
Have set up Selenium by setting up a Selenium grid within docker compose

To spin up docker containers run: 
    docker-compose up -d

This will spin up chrome and firebox browsers for our use in Selenium. If you want to view the browsers as the test runs you can run VNC servers:
    chrome at 127.0.0.1:5900
    firefox at 127.0.0.1:5901

To run the tests run:
    python manage.py test selenium_tests
