### PR TITLE
don't preload media (audio/video) assets on page load

### DIFF
--- a/home/blocks.py
+++ b/home/blocks.py
@@ -32,7 +32,7 @@ class MediaBlock(AbstractMediaChooserBlock):
         if value.type == 'video':
             player_code = '''
             <div>
-                <video width="320" height="240" {1} controls>
+                <video preload="none" width="320" height="240" {1} controls>
                     {0}
                     ''' + video_not_supported_text + '''
                 </video>
@@ -42,7 +42,7 @@ class MediaBlock(AbstractMediaChooserBlock):
         else:
             player_code = '''
             <div>
-                <audio controls>
+                <audio preload="none" controls>
                     {0}
                     ''' + audio_not_supported_text + '''
                 </audio>

--- a/iogt/views.py
+++ b/iogt/views.py
@@ -76,6 +76,7 @@ class SitemapAPIView(APIView):
 
         media_urls = []
         for media in Media.objects.all():
+            media_urls.append(f'{settings.MEDIA_URL}{media.file.name}')
             if media.thumbnail:
                 image_urls.append(f'{settings.MEDIA_URL}{media.thumbnail.name}')
 

--- a/iogt/views.py
+++ b/iogt/views.py
@@ -76,7 +76,6 @@ class SitemapAPIView(APIView):
 
         media_urls = []
         for media in Media.objects.all():
-            media_urls.append(f'{settings.MEDIA_URL}{media.file.name}')
             if media.thumbnail:
                 image_urls.append(f'{settings.MEDIA_URL}{media.thumbnail.name}')
 


### PR DESCRIPTION
Closes #1314 

- stopped pre-loading of audio/video assets