### PR TITLE
optimize user submission data export

### DIFF
--- a/questionnaires/views.py
+++ b/questionnaires/views.py
@@ -1,3 +1,6 @@
+import csv
+
+from django.http import HttpResponse
 from wagtail.contrib.forms.views import SubmissionsListView, FormPagesListView as WagtailFormPagesListView
 
 
@@ -17,3 +20,45 @@ class FormPagesListView(WagtailFormPagesListView):
 class CustomSubmissionsListView(SubmissionsListView):
     def get_filename(self):
         return self.form_page.get_export_filename()
+
+    def get_queryset(self):
+        """ Return queryset of form submissions with filter and order_by applied """
+        submission_class = self.form_page.get_submission_class()
+        queryset = submission_class._default_manager.filter(page=self.form_page).select_related('page', 'user')
+
+        filtering = self.get_filtering()
+        if filtering and isinstance(filtering, dict):
+            queryset = queryset.filter(**filtering)
+
+        ordering = self.get_ordering()
+        if ordering:
+            if isinstance(ordering, str):
+                ordering = (ordering,)
+            queryset = queryset.order_by(*ordering)
+
+        return queryset
+
+    def write_csv_row(self, writer, row_dict):
+        processed_row = {}
+        for field, value in row_dict.items():
+            preprocess_function = self.get_preprocess_function(
+                field, value, self.FORMAT_CSV
+            )
+            processed_value = (
+                preprocess_function(value) if preprocess_function else value
+            )
+            processed_row[field] = processed_value
+        return writer.writerow(processed_row.values())
+
+    def write_csv_response(self, queryset):
+        response = HttpResponse(
+            content_type='text/csv',
+        )
+        response["Content-Disposition"] = 'attachment; filename="{}.csv"'.format(
+            self.get_filename()
+        )
+        writer = csv.writer(response)
+        writer.writerow({field: self.get_heading(queryset, field) for field in self.list_export})
+        for item in queryset:
+            self.write_csv_row(writer, self.to_row_dict(item))
+        return response

--- a/questionnaires/views.py
+++ b/questionnaires/views.py
@@ -1,6 +1,3 @@
-import csv
-
-from django.http import HttpResponse
 from wagtail.contrib.forms.views import SubmissionsListView, FormPagesListView as WagtailFormPagesListView
 
 
@@ -23,30 +20,3 @@ class CustomSubmissionsListView(SubmissionsListView):
 
     def get_queryset(self):
         return super().get_queryset().select_related('page', 'user')
-
-    def process_csv_row(self, row_dict):
-        processed_row = {}
-        for field, value in row_dict.items():
-            preprocess_function = self.get_preprocess_function(
-                field, value, self.FORMAT_CSV
-            )
-            processed_value = (
-                preprocess_function(value) if preprocess_function else value
-            )
-            processed_row[field] = processed_value
-        return processed_row.values()
-
-    def write_csv_response(self, queryset):
-        response = HttpResponse(
-            content_type='text/csv',
-        )
-        response["Content-Disposition"] = 'attachment; filename="{}.csv"'.format(
-            self.get_filename()
-        )
-        writer = csv.writer(response)
-        writer.writerow({field: self.get_heading(queryset, field) for field in self.list_export})
-        items = []
-        for item in queryset:
-            items.append(self.process_csv_row(self.to_row_dict(item)))
-        writer.writerows(items)
-        return response


### PR DESCRIPTION
- we were including the user name and page URL in export
- for each user submission 2 additional queries were executed 
  - 1 for user and 1 for page
- pre-fetch both user and page with the user submission
- reduced complexity from O(n) to O(1)


e.g., for 2000 user submissions

- before optimization
1 query for user submissions
2000 queries for users
2000 queries for pages

- after optimization
1 query for user submission with pre-fetch of users and pages