### PR TITLE
filter out already md5 generated files as static return those

### DIFF
--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+import re
 from datetime import timedelta
 
 import allauth
@@ -490,3 +491,5 @@ if CACHE_BACKEND:
     }
 
 SITE_VERSION = os.getenv('SITE_VERSION', 'unknown')
+
+HAS_MD5_HASH_REGEX = re.compile(r"\.[a-f0-9]{12}\..*$")

--- a/iogt/tests.py
+++ b/iogt/tests.py
@@ -1,3 +1,5 @@
+import unittest
+
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
@@ -5,6 +7,8 @@ from wagtail.core.models import Site
 
 from home.factories import SectionFactory, ArticleFactory, HomePageFactory, SVGToPNGMapFactory
 from wagtail_factories import ImageFactory, SiteFactory
+
+from iogt.utils import has_md5_hash
 
 
 class PageTreeAPIViewTests(TestCase):
@@ -50,7 +54,31 @@ class PageTreeAPIViewTests(TestCase):
         response = self.client.get(reverse(self.url_name, kwargs={'page_id': self.home_page.id}))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('/static/css/iogt.css', response.data)
-        self.assertIn('/static/js/iogt.js', response.data)
-        self.assertIn('/static/icons/search.svg', response.data)
-        self.assertIn('/static/fonts/memSYaGs126MiZpBA-UvWbX2vVnXBbObj2OVZyOOSr4dVJWUgsg-1x4gaVQUwaEQbjA.woff', response.data)
+        self.assertTrue([item for item in response.data if item.startswith('/static/css/iogt')])
+        self.assertTrue([item for item in response.data if item.startswith('/static/js/iogt')])
+        self.assertTrue([item for item in response.data if item.startswith('/static/icons/search')])
+        self.assertTrue([item for item in response.data if item.startswith('/static/fonts/memSYaGs126MiZpBA-UvWbX2vVnXBbObj2OVZyOOSr4dVJWUgsg-1x4gaVQUwaEQbjA')])
+
+
+class TestUtils(unittest.TestCase):
+    def test_has_md5_hash_with_hash_values(self):
+        with_md5_hash = [
+            'iogt.c288d51a7c1f.css',
+            'iogt.9bbc5bdef847.js',
+            'search.6f2883e8e48b.svg',
+            'memSYaGs126MiZpBA-UvWbX2vVnXBbObj2OVZyOOSr4dVJWUgsg-1x4gaVQUwaEQbjA.186a2a0afcb7.woff',
+        ]
+
+        for value in with_md5_hash:
+            self.assertTrue(has_md5_hash(value))
+
+    def test_has_md5_hash_without_has_values(self):
+        without_md5_hash = [
+            'iogt.css',
+            'iogt.js',
+            'search.svg',
+            'memSYaGs126MiZpBA-UvWbX2vVnXBbObj2OVZyOOSr4dVJWUgsg-1x4gaVQUwaEQbjA.woff',
+        ]
+
+        for value in without_md5_hash:
+            self.assertFalse(has_md5_hash(value))

--- a/iogt/utils.py
+++ b/iogt/utils.py
@@ -1,0 +1,5 @@
+import re
+
+
+def has_md5_hash(name):
+    return bool(re.search(r"\.[a-f0-9]{12}\..*$", name))

--- a/iogt/utils.py
+++ b/iogt/utils.py
@@ -1,5 +1,5 @@
-import re
+from django.conf import settings
 
 
 def has_md5_hash(name):
-    return bool(re.search(r"\.[a-f0-9]{12}\..*$", name))
+    return bool(settings.HAS_MD5_HASH_REGEX.search(name))

--- a/iogt/views.py
+++ b/iogt/views.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path, PurePosixPath
 
 from django.conf import settings
@@ -130,8 +131,9 @@ class PageTreeAPIView(APIView):
             for root, dirs, files in os.walk(Path(settings.STATIC_ROOT).joinpath(static_dir['name'])):
                 for file in files:
                     if file.endswith(static_dir['extensions']):
-                        static_urls.append(
-                            static(f'{PurePosixPath(root).relative_to(settings.STATIC_ROOT).joinpath(file)}'))
+                        if not re.search('\.\w.*\.(css|js|svg|woff|woff2)', file):
+                            static_urls.append(
+                                static(f'{PurePosixPath(root).relative_to(settings.STATIC_ROOT).joinpath(file)}'))
 
 
         urls = set(flatten(

--- a/iogt/views.py
+++ b/iogt/views.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 from pathlib import Path, PurePosixPath
 
 from django.conf import settings
@@ -16,6 +15,7 @@ from wagtail.images.models import Rendition
 from wagtailmedia.models import Media
 
 from home.models import HomePage, Section, Article, OfflineAppPage, SVGToPNGMap, FooterPage
+from iogt.utils import has_md5_hash
 from questionnaires.models import Poll, Survey, Quiz
 
 logger = logging.getLogger(__name__)
@@ -135,7 +135,7 @@ class PageTreeAPIView(APIView):
                 for file in files:
                     if file.endswith(static_dir['extensions']):
                         try:
-                            if not re.search('\.[a-f0-9]{12}\..*$', file):
+                            if not has_md5_hash(file):
                                 static_urls.append(
                                     static(f'{PurePosixPath(root).relative_to(settings.STATIC_ROOT).joinpath(file)}'))
                         except Exception as e:

--- a/iogt/views.py
+++ b/iogt/views.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 from pathlib import Path, PurePosixPath
@@ -16,6 +17,8 @@ from wagtailmedia.models import Media
 
 from home.models import HomePage, Section, Article, OfflineAppPage, SVGToPNGMap, FooterPage
 from questionnaires.models import Poll, Survey, Quiz
+
+logger = logging.getLogger(__name__)
 
 
 class TransitionPageView(TemplateView):
@@ -131,10 +134,12 @@ class PageTreeAPIView(APIView):
             for root, dirs, files in os.walk(Path(settings.STATIC_ROOT).joinpath(static_dir['name'])):
                 for file in files:
                     if file.endswith(static_dir['extensions']):
-                        if not re.search('\.\w.*\.(css|js|svg|woff|woff2)', file):
-                            static_urls.append(
-                                static(f'{PurePosixPath(root).relative_to(settings.STATIC_ROOT).joinpath(file)}'))
-
+                        try:
+                            if not re.search('\.[a-f0-9]{12}\..*$', file):
+                                static_urls.append(
+                                    static(f'{PurePosixPath(root).relative_to(settings.STATIC_ROOT).joinpath(file)}'))
+                        except Exception as e:
+                            logger.exception(e)
 
         urls = set(flatten(
             page_urls +


### PR DESCRIPTION
- django's `static()` function relies on static files manifest
- django's `static()` function accepts the normal file path and returns the hash attached URL
- previously I was passing md5 attached file in `static()` and it was throwing an error
- now only pass normal files to `static()` and filter out md5 attached files