### PR TITLE
gracefully handle change of questions which already has submissions

### DIFF
--- a/questionnaires/tests.py
+++ b/questionnaires/tests.py
@@ -751,7 +751,7 @@ class FormDataPerUserAdminTests(TestCase):
 
         self.survey = SurveyFactory(parent=self.home_page, last_published_at=self.current_datetime - timedelta(days=1))
         GroupPagePermissionFactory(group=self.group, page=self.survey)
-        skip_logic = json.dumps(
+        self.skip_logic = json.dumps(
             [
                 {
                     "type": "skip_logic",
@@ -780,7 +780,7 @@ class FormDataPerUserAdminTests(TestCase):
             ]
         )
         self.survey_question = SurveyFormFieldFactory(
-            page=self.survey, field_type='checkboxes', skip_logic=skip_logic, default_value='c2')
+            page=self.survey, field_type='checkboxes', skip_logic=self.skip_logic, default_value='c2')
 
         self.quiz = QuizFactory(parent=self.home_page, last_published_at=self.current_datetime - timedelta(days=2))
         GroupPagePermissionFactory(group=self.group, page=self.quiz)
@@ -995,39 +995,12 @@ class FormDataPerUserAdminTests(TestCase):
 
     def test_csv_export_with_modified_questions(self):
         self.survey_question.delete()
-        skip_logic = json.dumps(
-            [
-                {
-                    "type": "skip_logic",
-                    "value": {
-                        "choice": "c1",
-                        "skip_logic": "next",
-                        "question": None
-                    }
-                },
-                {
-                    "type": "skip_logic",
-                    "value": {
-                        "choice": "c2",
-                        "skip_logic": "next",
-                        "question": None
-                    }
-                },
-                {
-                    "type": "skip_logic",
-                    "value": {
-                        "choice": "c3",
-                        "skip_logic": "next",
-                        "question": None
-                    }
-                }
-            ]
-        )
         survey_question = SurveyFormFieldFactory(
-            page=self.survey, label='Question 01', admin_label='Q 01', field_type='checkboxes', skip_logic=skip_logic, default_value='c2')
+            page=self.survey, label='Question 01', admin_label='Q 01', field_type='checkboxes',
+            skip_logic=self.skip_logic, default_value='c3')
         form_data = json.dumps({
             survey_question.clean_name: [
-                'c2',
+                'c3',
             ],
         })
         user_submission = UserSubmissionFactory(page=self.survey, user=self.user_01, form_data=form_data)
@@ -1045,7 +1018,7 @@ class FormDataPerUserAdminTests(TestCase):
             f'{self.user_submission_01.id},{self.poll.title},{self.user_submission_01.submit_time},{self.poll_question.admin_label},c1\r\n' \
             f'{user_submission.id},{self.survey.title},{user_submission.submit_time},User,{self.user_01.username}\r\n' \
             f'{user_submission.id},{self.survey.title},{user_submission.submit_time},URL,{self.survey.full_url}\r\n' \
-            f'{user_submission.id},{self.survey.title},{user_submission.submit_time},{survey_question.admin_label},c2\r\n' \
+            f'{user_submission.id},{self.survey.title},{user_submission.submit_time},{survey_question.admin_label},c3\r\n' \
             f'{self.user_submission_02.id},{self.survey.title},{self.user_submission_02.submit_time},User,{self.user_01.username}\r\n' \
             f'{self.user_submission_02.id},{self.survey.title},{self.user_submission_02.submit_time},URL,{self.survey.full_url}\r\n' \
             f'{self.user_submission_02.id},{self.survey.title},{self.user_submission_02.submit_time},{self.survey_question.admin_label},c2\r\n' \

--- a/questionnaires/tests.py
+++ b/questionnaires/tests.py
@@ -1006,24 +1006,18 @@ class FormDataPerUserAdminTests(TestCase):
         user_submission = UserSubmissionFactory(page=self.survey, user=self.user_01, form_data=form_data)
         user_submission.submit_time = self.current_datetime
         user_submission.save()
-        response = self.client.get(f'{self.url}?user_id={self.user_01.id}&export=csv')
+        response = self.client.get(f'{self.url}?user_id={self.user_01.id}&export=csv&page_ids={self.survey.id}')
 
         byte_response = b''
         for stream in response.streaming_content:
             byte_response += stream
         expected_response = \
             f'ID,Name,Submission Date,Field,Value\r\n' \
-            f'{self.user_submission_01.id},{self.poll.title},{self.user_submission_01.submit_time},User,{self.user_01.username}\r\n' \
-            f'{self.user_submission_01.id},{self.poll.title},{self.user_submission_01.submit_time},URL,{self.poll.full_url}\r\n' \
-            f'{self.user_submission_01.id},{self.poll.title},{self.user_submission_01.submit_time},{self.poll_question.admin_label},c1\r\n' \
             f'{user_submission.id},{self.survey.title},{user_submission.submit_time},User,{self.user_01.username}\r\n' \
             f'{user_submission.id},{self.survey.title},{user_submission.submit_time},URL,{self.survey.full_url}\r\n' \
-            f'{user_submission.id},{self.survey.title},{user_submission.submit_time},{survey_question.admin_label},c3\r\n' \
+            f'{user_submission.id},{self.survey.title},{user_submission.submit_time},Q 01,c3\r\n' \
             f'{self.user_submission_02.id},{self.survey.title},{self.user_submission_02.submit_time},User,{self.user_01.username}\r\n' \
             f'{self.user_submission_02.id},{self.survey.title},{self.user_submission_02.submit_time},URL,{self.survey.full_url}\r\n' \
-            f'{self.user_submission_02.id},{self.survey.title},{self.user_submission_02.submit_time},{self.survey_question.admin_label},c2\r\n' \
-            f'{self.user_submission_03.id},{self.quiz.title},{self.user_submission_03.submit_time},User,{self.user_01.username}\r\n' \
-            f'{self.user_submission_03.id},{self.quiz.title},{self.user_submission_03.submit_time},URL,{self.quiz.full_url}\r\n' \
-            f'{self.user_submission_03.id},{self.quiz.title},{self.user_submission_03.submit_time},{self.quiz_question.admin_label},c3\r\n'
+            f'{self.user_submission_02.id},{self.survey.title},{self.user_submission_02.submit_time},{self.survey_question.admin_label},c2\r\n'
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(byte_response.decode(), expected_response)

--- a/questionnaires/views.py
+++ b/questionnaires/views.py
@@ -131,7 +131,7 @@ class FormDataPerUserView(SpreadsheetExportMixin, SafePaginateListView):
         }
         for clean_name, answer in json.loads(item.form_data).items():
             data.update({
-                form_fields_dict.get(item.page_id, {}).get(clean_name): answer,
+                form_fields_dict.get(item.page_id, {}).get(clean_name, clean_name): answer,
             })
         return [dict(zip(self.list_export, [item.id, item.page.title, item.submit_time, field, value]))
                 for field, value in data.items()]

--- a/questionnaires/views.py
+++ b/questionnaires/views.py
@@ -131,7 +131,7 @@ class FormDataPerUserView(SpreadsheetExportMixin, SafePaginateListView):
         }
         for clean_name, answer in json.loads(item.form_data).items():
             data.update({
-                form_fields_dict[item.page_id][clean_name]: answer,
+                form_fields_dict.get(item.page_id, {}).get(clean_name): answer,
             })
         return [dict(zip(self.list_export, [item.id, item.page.title, item.submit_time, field, value]))
                 for field, value in data.items()]


### PR DESCRIPTION
- questionnaires having submissions of deleted questions can't be exported
- uses clean name for deleted questions in export