### PR TITLE
hides double menu for js enabled devices

### DIFF
--- a/iogt/static/js/iogt.js
+++ b/iogt/static/js/iogt.js
@@ -118,6 +118,9 @@ $(document).ready(() => {
     $(window).on('online', () => enableForOnlineAccess());
 
     window.navigator.onLine ? enableForOnlineAccess() : disableForOfflineAccess();
+
+    // for JS enabled devices hide double menu
+    $('#menu').hide();
 });
 
 const download = pageId => {


### PR DESCRIPTION
Closes #1400 

- don't show a double menu for JavaScript enabled devices

for chrome one can enable/disable JS as follows
<img width="2054" alt="Screenshot 2022-09-11 at 12 22 07 PM" src="https://user-images.githubusercontent.com/49383675/189520486-c43bfbf8-ba1e-4b5d-96f3-333525dc8c98.png">
<img width="2056" alt="Screenshot 2022-09-11 at 12 22 21 PM" src="https://user-images.githubusercontent.com/49383675/189520497-5062b91b-2c20-45b9-acb7-1e4a609574e8.png">
<img width="1566" alt="Screenshot 2022-09-11 at 12 22 33 PM" src="https://user-images.githubusercontent.com/49383675/189520505-d293cbd1-f26e-4ee0-b062-72d4270dd3d1.png">
