### PR TITLE
Remove view live for not previewable pages

### DIFF
--- a/home/mixins.py
+++ b/home/mixins.py
@@ -95,3 +95,8 @@ class TitleIconMixin:
             icon = Icon(self.image_icon.get_rendition('fill-32x32').url, False)
 
         return icon
+
+
+class ViewLiveMixIn:
+    def should_view_live_on_admin(self):
+        return False

--- a/home/models.py
+++ b/home/models.py
@@ -49,7 +49,7 @@ from .blocks import (
     EmbeddedQuizBlock, PageButtonBlock, NumberedListBlock, RawHTMLBlock, ArticleBlock, DownloadButtonBlock,
 )
 from .forms import SectionPageForm
-from .mixins import PageUtilsMixin, TitleIconMixin
+from .mixins import PageUtilsMixin, TitleIconMixin, ViewLiveMixIn
 from .utils.image import convert_svg_to_png_bytes
 from .utils.progress_manager import ProgressManager
 import iogt.iogt_globals as globals_
@@ -127,7 +127,7 @@ class ArticleTaggedItem(TaggedItemBase):
                                  on_delete=models.CASCADE)
 
 
-class SectionIndexPage(Page):
+class SectionIndexPage(Page, ViewLiveMixIn):
     parent_page_types = ['home.HomePage']
     subpage_types = ['home.Section']
 
@@ -461,7 +461,7 @@ class Article(AbstractArticle):
         return response
 
 
-class MiscellaneousIndexPage(Page):
+class MiscellaneousIndexPage(Page, ViewLiveMixIn):
     parent_page_types = ['home.HomePage']
     subpage_types = ['home.OfflineContentIndexPage']
 
@@ -475,12 +475,12 @@ class OfflineContentIndexPage(AbstractArticle):
         verbose_name = 'Offline Content Index Page'
 
 
-class BannerIndexPage(Page):
+class BannerIndexPage(Page, ViewLiveMixIn):
     parent_page_types = ['home.HomePage']
     subpage_types = ['home.BannerPage']
 
 
-class BannerPage(Page, PageUtilsMixin):
+class BannerPage(Page, PageUtilsMixin, ViewLiveMixIn):
     parent_page_types = ['home.BannerIndexPage']
     subpage_types = []
 
@@ -511,7 +511,7 @@ class BannerPage(Page, PageUtilsMixin):
         return image_urls
 
 
-class FooterIndexPage(Page):
+class FooterIndexPage(Page, ViewLiveMixIn):
     parent_page_types = ['home.HomePage']
     subpage_types = [
         'home.Section', 'home.Article', 'home.PageLinkPage', 'questionnaires.Poll',

--- a/iogt/templates/wagtailadmin/home/recent_edits.html
+++ b/iogt/templates/wagtailadmin/home/recent_edits.html
@@ -42,7 +42,7 @@
                                 {% if page.has_unpublished_changes and page.is_previewable %}
                                     <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Draft' %}</a></li>
                                 {% endif %}
-                                {% if page.live %}
+                                {% if page.live and page.should_view_live_on_admin != False %}
                                     {% with page_url=page.url %}
                                         {% if page_url is not None %}
                                             <li><a href="{{ page_url }}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Live' %}</a></li>

--- a/iogt/templates/wagtailadmin/pages/_page_view_live_tag.html
+++ b/iogt/templates/wagtailadmin/pages/_page_view_live_tag.html
@@ -1,0 +1,9 @@
+{% load i18n wagtailadmin_tags %}
+{% if page.live and page.url is not None and page.should_view_live_on_admin != False %}
+    {% test_page_is_public page as is_public %}
+    <a href="{{ page.url }}" target="_blank" rel="noopener noreferrer" class="button button-nostroke button--live" title="{% trans 'Visit the live page' %}">
+        {% icon name="link-external" class_name="initial" %}
+        {% trans "Live" %}
+        <span class="privacy-indicator-tag {% if is_public %}u-hidden" aria-hidden="true{% endif %}" title="{% trans "This page is live but only available to certain users" %}">({% trans "restricted" %})</span>
+    </a>
+{% endif %}

--- a/iogt/templates/wagtailadmin/pages/_preview_button_on_edit.html
+++ b/iogt/templates/wagtailadmin/pages/_preview_button_on_edit.html
@@ -1,0 +1,8 @@
+{% load wagtailadmin_tags %}
+
+{% if page.should_view_live_on_admin != False %}
+{% auto_update_preview as auto_update %}
+    <button class="button action-preview {% if icon %}button--icon{% endif %}"
+        data-action="{% url 'wagtailadmin_pages:preview_on_edit' page.id %}{% if mode %}?mode={{ mode|urlencode }}{% endif %}"
+        data-auto-update="{{ auto_update|yesno:'true,false' }}">{% if icon %}{% icon name="view" %}{% endif %}{{ label }}</button>
+{% endif %}

--- a/iogt/templates/wagtailadmin/pages/listing/_buttons.html
+++ b/iogt/templates/wagtailadmin/pages/listing/_buttons.html
@@ -1,0 +1,7 @@
+{% for button in buttons %}
+  {% if button.show %}
+    {% if button.label != 'View live' or page.should_view_live_on_admin != False %}
+        <li>{{ button|safe }}</li>
+    {% endif %}
+  {% endif %}
+{% endfor %}

--- a/iogt/templates/wagtailadmin/shared/page_status_tag.html
+++ b/iogt/templates/wagtailadmin/shared/page_status_tag.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+{% if page.should_view_live_on_admin != False %}
+    {% if page.live %}
+        {% with page_url=page.url %}
+            {% if page_url is not None %}
+                <a href="{{ page_url }}" target="_blank" rel="noopener noreferrer" class="status-tag primary" title="{% trans 'Visit the live page' %}">
+                    <span class="visuallyhidden">{% trans "Current page status:" %}</span> {{ page.status_string }}
+                </a>
+            {% else %}
+                <span class="status-tag primary">
+                    <span class="visuallyhidden">{% trans "Current page status:" %}</span> {{ page.status_string }}
+                </span>
+            {% endif %}
+        {% endwith %}
+    {% else %}
+        <span class="status-tag">
+            <span class="visuallyhidden">{% trans "Current page status:" %}</span> {{ page.status_string }}
+        </span>
+    {% endif %}
+{% endif %}


### PR DESCRIPTION
Closes #348

- There was an issue on admin panel, admin see the "View Live" button for the pages that are not previewable (404 page not found error). 
- In this enhancement admin will not be able to view pages which are not previewable. 
- Just inherit the class from ViewLiveMixIn to make it not able to preview.