### PR TITLE
Fix poll results for checkboxes

### DIFF
--- a/questionnaires/templates/poll/poll_landing.html
+++ b/questionnaires/templates/poll/poll_landing.html
@@ -21,11 +21,11 @@
                             {% for question, answers in results.items %}
                                 {% snake_case question as current_answer %}
                                 {% for answer, count in answers.items %}
-                                    <div class="cust-check cust-check--white polls-widget__item{% if answer == request.POST|get_value_from_querydict:current_answer %} cust-check--active{% endif %}">
+                                    <div class="cust-check cust-check--white polls-widget__item{% if answer in request.POST|get_values_from_querydict:current_answer %} cust-check--active{% endif %}">
                                         <div class="cust-check__title">
                                             <div class="cust-check__title-left">
                                                 <span>{{ answer }}</span>
-                                                {% if answer == request.POST|get_value_from_querydict:current_answer %}
+                                                    {% if answer in request.POST|get_values_from_querydict:current_answer %}
                                                     <span class="cust-check__subtitle">{% translate "Your answer" %}</span>{% endif %}
                                             </div>
                                             <div class="cust-check__title-right">

--- a/questionnaires/templatetags/questionnaires_tags.py
+++ b/questionnaires/templatetags/questionnaires_tags.py
@@ -141,9 +141,9 @@ def get_item(dictionary, key):
 
 
 @register.filter
-def get_value_from_querydict(querydict, key):
+def get_values_from_querydict(querydict, key):
     dictionary = dict(querydict)
-    return dictionary.get(key)[0]
+    return dictionary[key]
 
 
 @register.simple_tag


### PR DESCRIPTION
Closes #1306 

- Previously poll results for check boxes question type only show "Your answer" for one option.
- Now it will show "Your answer"  for all selected boxes.

![image](https://user-images.githubusercontent.com/62539376/195019061-4ccd58bb-eacc-4112-a1e9-9d1f8d8e8e1f.png)
![image](https://user-images.githubusercontent.com/62539376/195019183-b94ef918-d4ab-46c1-a5c2-a9010a419251.png)
