### PR TITLE
Fix questionnaires choices with surrounding spaces

### DIFF
--- a/questionnaires/models.py
+++ b/questionnaires/models.py
@@ -634,7 +634,7 @@ class Poll(QuestionnairePage, AbstractForm):
         if len(submissions) > 0 and self.show_results_with_no_votes:
             for _, label, choices in data_fields:
                 results[label] = {
-                    choice: 0 for choice in choices.split('|') if len(choice) > 0
+                    choice.strip(): 0 for choice in choices.split('|') if len(choice) > 0
                 }
 
         for submission in submissions:


### PR DESCRIPTION
Closes #1421 

- There was an issue of duplicates when questionnaires choices are submitted with surrounding spaces 
- Issue is fixed now
  
![image](https://user-images.githubusercontent.com/62539376/195073318-f9f95395-523c-451e-85e7-6ed77c892159.png)
