### PR TITLE
Display feedback on unselected answers

### DIFF
--- a/questionnaires/models.py
+++ b/questionnaires/models.py
@@ -783,6 +783,11 @@ class QuizFormField(AbstractFormField):
 class Quiz(QuestionnairePage, AbstractForm):
     base_form_class = QuizForm
     form_builder = CustomFormBuilder
+    display_unselected_answers = models.BooleanField(default=False)
+
+    settings_panels = AbstractForm.settings_panels + [
+        FieldPanel('display_unselected_answers')
+    ]
 
     parent_page_types = [
         "home.HomePage", "home.Section", "home.Article", "questionnaires.QuizIndexPage", 'home.FooterIndexPage',

--- a/questionnaires/templatetags/questionnaires_tags.py
+++ b/questionnaires/templatetags/questionnaires_tags.py
@@ -172,7 +172,9 @@ def get_answer_options(field, field_option, fields_info):
     label = field_option.choice_label
     correct_answers = fields_info.get(field.name, {}).get('correct_answer_list', [])
     is_selected = field_option.data.get('selected', False)
+    is_display_unselected_answers = field.form.page.display_unselected_answers
     rv = ''
+
     if is_selected and label in correct_answers:
         rv = {
             'class': 'success',
@@ -183,12 +185,12 @@ def get_answer_options(field, field_option, fields_info):
             'class': 'error',
             'aria_label': 'Checkbox with X, indicating incorrect and selected',
         }
-    elif not is_selected and label in correct_answers:
+    elif is_display_unselected_answers and not is_selected and label in correct_answers:
         rv = {
             'class': 'clear-tick',
             'aria_label': 'Checkbox with tick, indicating correct but not selected',
         }
-    elif not is_selected and label not in correct_answers:
+    elif is_display_unselected_answers and not is_selected and label not in correct_answers:
         rv = {
             'class': 'clear-cross',
             'aria_label': 'Checkbox with X, indicating incorrect and not selected',


### PR DESCRIPTION
Closes #423 

- Previously there were no option to restrict the visibility of feedback on unselected answers. 
- Now admin can restrict the visibility in settings tab.
   
![image](https://user-images.githubusercontent.com/62539376/196156842-5113ce20-b32b-41dc-997c-71ec8b3200a9.png)

- if you want to display feedback on unselected answers just tick the the "DISPLAY UNSELECTED ANSWERS". 