### PR TITLE
fixes font family order

### DIFF
--- a/comments/static/css/report-page/report-page.css
+++ b/comments/static/css/report-page/report-page.css
@@ -1,6 +1,5 @@
 .report-page {
   padding: 12px;
-  font-family: Poppins;
   font-style: normal;
   font-weight: 500;
   font-size: 10px;

--- a/comments/static/css/report-page/report-page.scss
+++ b/comments/static/css/report-page/report-page.scss
@@ -3,7 +3,6 @@
 
 .report-page {
     padding: 12px;
-    font-family: Poppins;
     font-style: normal;
     font-weight: 500;
     font-size: 10px;

--- a/home/static/css/global/global.css
+++ b/home/static/css/global/global.css
@@ -61,7 +61,6 @@
 
 .featured-content a {
   text-decoration: none;
-  font-family: Poppins;
   font-style: normal;
   font-weight: bold;
   font-size: 10px;
@@ -93,7 +92,6 @@
   display: flex;
   flex-direction: column;
   text-decoration: none;
-  font-family: Poppins;
   font-style: normal;
   font-weight: bold;
   font-size: 10px;
@@ -134,7 +132,6 @@
           justify-content: space-between;
   padding: 8px 12px;
   border-bottom: 1px solid #EFEFEF;
-  font-family: Poppins;
   font-style: normal;
   font-weight: bold;
   font-size: 10px;
@@ -200,7 +197,6 @@
 .article__content {
   padding: 0px 12px;
   padding: 0 !important;
-  font-family: Poppins;
 }
 
 .article__content img,
@@ -327,7 +323,6 @@
   height: 32px;
   border-radius: 18px;
   margin-bottom: 12px;
-  font-family: Poppins;
   font-style: normal;
   font-weight: 600;
 }
@@ -372,7 +367,6 @@
 }
 
 .comments {
-  font-family: Poppins;
   font-style: normal;
 }
 
@@ -538,7 +532,6 @@
   margin-top: 1px;
   padding: 12px;
   background: #F7F7F9;
-  font-family: Poppins;
   font-style: normal;
 }
 
@@ -744,8 +737,6 @@ body.rtl {
 }
 
 .article-card {
-  /* margin: 0px 12px; */
-  font-family: Poppins;
   font-style: normal;
 }
 
@@ -914,7 +905,6 @@ body.rtl {
 }
 
 .questionnaire-components p {
-  font-family: Poppins;
   font-style: normal;
   padding-right: 20px;
   margin: 0;
@@ -1018,7 +1008,6 @@ body.rtl {
     height: 26px;
     background: #0094F4;
     border-radius: 8px;
-    font-family: Poppins;
     font-style: normal;
     font-weight: 600;
     font-size: 16px;
@@ -1214,7 +1203,6 @@ body.rtl {
 .search__form input {
   border: none;
   background: #F7F7F9;
-  font-family: 'Poppins';
   font-style: normal;
   font-weight: 500;
   font-size: 16px;
@@ -1279,7 +1267,6 @@ body.rtl {
   background: #FDD256;
   border: none;
   border-radius: 8px;
-  font-family: Poppins;
   font-style: normal;
   font-weight: 600;
   font-size: 12px;
@@ -1341,7 +1328,6 @@ body.rtl {
   min-width: 80px;
   /* max-width: 80px; */
   text-decoration: none;
-  font-family: Poppins;
   font-style: normal;
   font-weight: 600;
   font-size: 12px;
@@ -1396,7 +1382,6 @@ body.rtl {
 }
 
 .language_drop .drop a {
-  font-family: 'Poppins';
   font-style: normal;
   font-weight: 600;
   font-size: 10px;

--- a/iogt/static/css/chatbot.css
+++ b/iogt/static/css/chatbot.css
@@ -269,7 +269,6 @@
 .search-box .search-box {
     border: 1px solid #efefef;
     background: #F7F7F9;
-    font-family: 'Poppins';
     font-style: normal;
     font-weight: 500;
     line-height: 20px;

--- a/iogt/static/css/footer/footer.css
+++ b/iogt/static/css/footer/footer.css
@@ -41,7 +41,6 @@
 .footer__form input {
   border: none;
   background: #F7F7F9;
-  font-family: Poppins;
   font-style: normal;
   font-weight: 500;
   line-height: 22px;
@@ -111,7 +110,6 @@
 .bottom-level {
   margin-top: 12px;
   border-top: 1px solid #EFEFEF;
-  font-family: Poppins;
   font-style: normal;
 }
 

--- a/iogt/static/css/footer/footer.scss
+++ b/iogt/static/css/footer/footer.scss
@@ -37,7 +37,6 @@
       input {
         border: none;
         background: $pearl;
-        font-family: Poppins;
         font-style: normal;
         font-weight: 500;
         line-height: 22px;
@@ -99,7 +98,6 @@
   .bottom-level {
     margin-top: 12px;
     border-top: 1px solid $fog;
-    font-family: Poppins;
     font-style: normal;
   
     &__section {

--- a/iogt/static/css/header/header.css
+++ b/iogt/static/css/header/header.css
@@ -25,7 +25,6 @@
   background-color: #FDD256;
   border: none;
   border-radius: 8px;
-  font-family: Poppins;
   font-style: normal;
   color: #303030;
   padding: 2px;
@@ -66,7 +65,6 @@
     background: #FDD256;
     border: none;
     border-radius: 8px;
-    font-family: Poppins;
     font-style: normal;
     font-weight: 600;
     font-size: 12px;
@@ -108,7 +106,6 @@
     background: #FDD256;
     border: none;
     border-radius: 8px;
-    font-family: Poppins;
     font-style: normal;
     font-weight: 600;
     font-size: 12px;

--- a/iogt/static/css/header/header.scss
+++ b/iogt/static/css/header/header.scss
@@ -21,7 +21,6 @@
     background-color: $gold;
     border: none;
     border-radius: 8px;
-    font-family: Poppins;
     font-style: normal;
     color: $black;
     padding: 2px;
@@ -51,7 +50,6 @@
       background: $gold;
       border: none;
       border-radius: 8px;
-      font-family: Poppins;
       font-style: normal;
       font-weight: 600;
       font-size: 12px;
@@ -79,7 +77,6 @@
         background: $gold;
         border: none;
         border-radius: 8px;
-        font-family: Poppins;
         font-style: normal;
         font-weight: 600;
         font-size: 12px;

--- a/iogt/static/css/iogt.css
+++ b/iogt/static/css/iogt.css
@@ -476,7 +476,7 @@ body {
     margin: 0;
     padding: 0;
     scroll-behavior: smooth;
-    font-family: "Poppins", -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-family: Poppins, "Open Sans", -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     font-weight: 400;
@@ -508,7 +508,6 @@ img {
 
 .title {
     color: #303030;
-    font-family: Poppins, sans-serif;
     font-size: 16px
 }
 
@@ -580,19 +579,16 @@ input:focus, input:focus-visible {
 
 .cust-input input::-webkit-input-placeholder, .cust-input textarea::-webkit-input-placeholder {
     color: #9a9a9a;
-    font-family: Poppins, sans-serif;
     font-weight: 500
 }
 
 .cust-input input:-ms-input-placeholder, .cust-input textarea:-ms-input-placeholder {
     color: #9a9a9a;
-    font-family: Poppins, sans-serif;
     font-weight: 500
 }
 
 .cust-input input::placeholder, .cust-input textarea::placeholder {
     color: #9a9a9a;
-    font-family: Poppins, sans-serif;
     font-weight: 500
 }
 


### PR DESCRIPTION
Closes #1399 

- update font-family order
- if Poppins doesn't support glyphs then "Open Sans" will take over
- reference: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family