### PR TITLE
Hold djangorestframework at v3.13.x due to breaking change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,10 +22,11 @@ wagtailmenus~=3.0
 wagtailsvg==0.0.14
 whitenoise==5.2.*
 django-health-check==3.16.5
+djangorestframework~=3.13.1
 djangorestframework-simplejwt==5.0.0
 django-redis==5.2.0
 django-google-analytics-app==5.0.5
 django-filter==2.4.0
-drf-yasg==1.21.3
+drf-yasg~=1.21.3
 django-webpush==0.3.4
 git+https://github.com/IDEMSInternational/wagtail-transfer.git@enh/show-error-for-unimported-referenced-pages#egg=wagtail-transfer


### PR DESCRIPTION
drf-yasg still uses 'NullBooleanField' from djangorestframework, which was deprecated and has now been removed.

This was causing the tests to fail.