### PR TITLE
Hide language selector when there is only one language

### DIFF
--- a/home/templates/home/tags/language_switcher.html
+++ b/home/templates/home/tags/language_switcher.html
@@ -1,5 +1,5 @@
 {% load generic_components %}
-{% if language_options|length > 1%}
+{% if language_options|length > 1 %}
 <div class="language_drop">
     <a href="#" style="{% language_picker_style %}">
         {{ current_language.name_local }}

--- a/home/templates/home/tags/language_switcher.html
+++ b/home/templates/home/tags/language_switcher.html
@@ -1,16 +1,18 @@
 {% load generic_components %}
-<div class="language_drop">
-    <a href="#" style="{% language_picker_style %}">
-        {{ current_language.name_local }}
-        <span class="arrow"></span>
-    </a>
-    <ul class="drop">
-    {% for option in language_options %}
-        <li class="{% if option.selected %}selected{% endif %}">
-            <a href="{{ option.url }}" rel="alternate" hreflang="{{ option.language.code }}">
-                {{ option.language.name_local }}
-            </a>
-        </li>
-    {% endfor %}
-    </ul>
-</div>
+{% if language_options|length > 1 %}
+    <div class="language_drop">
+        <a href="#" style="{% language_picker_style %}">
+            {{ current_language.name_local }}
+            <span class="arrow"></span>
+        </a>
+        <ul class="drop">
+        {% for option in language_options %}
+            <li class="{% if option.selected %}selected{% endif %}">
+                <a href="{{ option.url }}" rel="alternate" hreflang="{{ option.language.code }}">
+                    {{ option.language.name_local }}
+                </a>
+            </li>
+        {% endfor %}
+        </ul>
+    </div>
+{% endif %}

--- a/home/templates/home/tags/language_switcher.html
+++ b/home/templates/home/tags/language_switcher.html
@@ -1,18 +1,18 @@
 {% load generic_components %}
-{% if language_options|length > 1 %}
-    <div class="language_drop">
-        <a href="#" style="{% language_picker_style %}">
-            {{ current_language.name_local }}
-            <span class="arrow"></span>
-        </a>
-        <ul class="drop">
-        {% for option in language_options %}
-            <li class="{% if option.selected %}selected{% endif %}">
-                <a href="{{ option.url }}" rel="alternate" hreflang="{{ option.language.code }}">
-                    {{ option.language.name_local }}
-                </a>
-            </li>
-        {% endfor %}
-        </ul>
-    </div>
+{% if language_options|length > 1%}
+<div class="language_drop">
+    <a href="#" style="{% language_picker_style %}">
+        {{ current_language.name_local }}
+        <span class="arrow"></span>
+    </a>
+    <ul class="drop">
+    {% for option in language_options %}
+        <li class="{% if option.selected %}selected{% endif %}">
+            <a href="{{ option.url }}" rel="alternate" hreflang="{{ option.language.code }}">
+                {{ option.language.name_local }}
+            </a>
+        </li>
+    {% endfor %}
+    </ul>
+</div>
 {% endif %}


### PR DESCRIPTION
Closes #748 

- Previously language selector were shown when there were only one language on site.
![image](https://user-images.githubusercontent.com/62539376/198554772-292628b1-b117-40a3-8cce-419f529447e8.png)

- This problem is fixed now
![image](https://user-images.githubusercontent.com/62539376/198554607-771c0f05-5afa-40d1-9ecc-998359bfd881.png)
