### PR TITLE
fix permission issue for wagtail transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ In `iogt/settings/local.py`, define [parameters from wagtail-transfer](https://g
 WAGTAILTRANSFER_SECRET_KEY = 'fake_secret_key'
 WAGTAILTRANSFER_SOURCES = {
    'iogt_global': {
-      'BASE_URL': 'http://fake-iogt-url.org',
+      'BASE_URL': 'http://fake-iogt-url.org/wagtail-transfer/',
       'SECRET_KEY': 'fake_secret_key_2',
    },
 }

--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -473,9 +473,6 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
-    'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
-    ],
     'DEFAULT_FILTER_BACKENDS': (
         'django_filters.rest_framework.DjangoFilterBackend',
     ),

--- a/iogt/settings/docker_compose_dev.py
+++ b/iogt/settings/docker_compose_dev.py
@@ -15,14 +15,6 @@ WAGTAILSEARCH_BACKENDS = {
 }
 
 
-WAGTAILTRANSFER_SECRET_KEY = os.environ.get('WAGTAILTRANSFER_SECRET_KEY')
-WAGTAILTRANSFER_SOURCES = {
-   os.environ.get('WAGTAILTRANSFER_SOURCE_NAME', 'default'): {
-      'BASE_URL': os.environ.get('WAGTAILTRANSFER_SOURCE_BASE_URL'),
-      'SECRET_KEY': os.environ.get('WAGTAILTRANSFER_SOURCE_SECRET_KEY'),
-   },
-}
-
 # Uncomment if you want to run Postgres
 # DATABASES = {
 #     'default': {

--- a/questionnaires/api/v1/views.py
+++ b/questionnaires/api/v1/views.py
@@ -3,6 +3,7 @@ from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.permissions import IsAuthenticated
 from wagtail.contrib.forms.utils import get_forms_for_user
 
 from questionnaires.filters import QuestionnaireFilter, UserSubmissionFilter
@@ -32,6 +33,7 @@ from questionnaires.serializers import (
     }
 ))
 class QuestionnairesListAPIView(ListAPIView):
+    permission_classes = (IsAuthenticated,)
     serializer_class = QuestionnairePageSerializer
     filterset_class = QuestionnaireFilter
     pagination_class = IoGTPagination
@@ -49,6 +51,8 @@ class QuestionnairesListAPIView(ListAPIView):
     }
 ))
 class QuestionnaireDetailAPIView(RetrieveAPIView):
+    permission_classes = (IsAuthenticated,)
+
     def get_queryset(self):
         return get_forms_for_user(self.request.user).specific().order_by('-last_published_at')
 
@@ -76,6 +80,7 @@ class QuestionnaireDetailAPIView(RetrieveAPIView):
     }
 ))
 class QuestionnaireSubmissionsAPIView(ListAPIView):
+    permission_classes = (IsAuthenticated,)
     serializer_class = UserSubmissionSerializer
     filterset_class = UserSubmissionFilter
     pagination_class = IoGTPagination


### PR DESCRIPTION
Closes #1447 

- DRF permissions were added globally on all APIs including the wagtail transfer
- remove global DRF permissions and limit those to specific questionnaire APIs
- removes wagtail transfer config from `docker_compose_dev.py`, not needed
- update readme for wagtail transfer