### PR TITLE
Add Heading and Paragraph content blocks to Featured Content

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -64,6 +64,8 @@ class HomePage(Page, PageUtilsMixin, TitleIconMixin):
     show_in_menus_default = True
 
     home_featured_content = StreamField([
+        ('heading', blocks.CharBlock(form_classname="full title", template='blocks/heading.html')),
+        ('paragraph', blocks.RichTextBlock(features=settings.WAGTAIL_RICH_TEXT_FIELD_FEATURES)),
         ('page_button', PageButtonBlock()),
         ('embedded_poll', EmbeddedPollBlock()),
         ('embedded_survey', EmbeddedSurveyBlock()),


### PR DESCRIPTION
Closes #687 

- Heading and Paragraph content blocks are added to Homepage Featured Content
![image](https://user-images.githubusercontent.com/62539376/199665246-b7b3aa94-b430-4fb2-9aa2-d34e44af304f.png)
