### PR TITLE
fixes article content panel

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -439,7 +439,10 @@ class Article(AbstractArticle):
         MultiFieldPanel([FieldPanel("tags"), ], heading='Metadata'),
     ]
 
-    edit_handler_list = AbstractArticle.edit_handler_list + [
+    edit_handler_list = [
+        ObjectList(content_panels, heading='Content'),
+        ObjectList(Page.settings_panels, heading='Settings'),
+        ObjectList(CommentableMixin.comments_panels, heading='Comments'),
         ObjectList(promote_panels, heading='Promote'),
     ]
 


### PR DESCRIPTION
Closes #1497 

- Recommend content field was missing from content panel list
- Added it to content panel list in article
<img width="952" alt="Screenshot 2022-12-28 at 3 36 07 PM" src="https://user-images.githubusercontent.com/49383675/209799099-317ab887-ff4a-4889-88aa-05487d65de37.png">
