### PR TITLE
adds sort child pages button

### DIFF
--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -12,6 +12,8 @@ from django.utils.html import format_html
 from wagtail.core import hooks
 from wagtail.core.models import Page
 from wagtail.core.models import PageViewRestriction
+from wagtail.admin import widgets as wagtailadmin_widgets
+
 
 from home.models import FooterIndexPage, BannerIndexPage, Section, \
     SectionIndexPage, LocaleDetail
@@ -85,6 +87,18 @@ def global_admin_js():
         '<script src="{}"></script>',
         static("js/global/admin.js")
     )
+
+
+@hooks.register('register_page_listing_buttons')
+def page_listing_buttons(page, page_perms, is_parent=False, next_url=None):
+    # Using more menu's "Sort menu order" button from wagtail
+    if is_parent:
+        yield wagtailadmin_widgets.PageListingButton(
+            _('Sort child pages'),
+            '?ordering=ord',
+            attrs={'title': _("Change ordering of child pages of '%(title)s'") % {'title': page.get_admin_display_title()}},
+            priority=60
+        )
 
 
 class LimitedTranslatableStringsFilter(SimpleListFilter):


### PR DESCRIPTION
Closes #1496 

- Adds "SORT CHILD PAGES" button alongside page buttons

<img width="635" alt="Screenshot 2022-12-28 at 10 23 37 PM" src="https://user-images.githubusercontent.com/49383675/209849553-d8715c1c-86d5-4343-b57d-20590d33d223.png">
