### PR TITLE
fixes html structure for menu

### DIFF
--- a/iogt/static/js/iogt.js
+++ b/iogt/static/js/iogt.js
@@ -120,7 +120,7 @@ $(document).ready(() => {
     window.navigator.onLine ? enableForOnlineAccess() : disableForOfflineAccess();
 
     // for JS enabled devices hide double menu
-    $('#menu').hide();
+    $('.footer-head').hide();
 });
 
 const download = pageId => {

--- a/iogt/templates/footer.html
+++ b/iogt/templates/footer.html
@@ -7,17 +7,19 @@
 {% get_current_language as LANGUAGE_CODE %}
 
 <footer class='footer-main'>
- {% flat_menu LANGUAGE_CODE|add:'_menu_live' template="nav_bar.html" %}
-    <div id="menu" class="footer-head">
-        {% include "header.html" %}
-    </div>
-    <div class='footer'>
-        <div class="section-container">
-            {% render_top_level_sections %}
-            {% if show_footers %}
-                {% render_footer %}
-            {% endif %}
-            <p class='footer__copyright'>{% translate "© The Internet of Good Things"%}</p>
+    {% flat_menu LANGUAGE_CODE|add:'_menu_live' template="nav_bar.html" %}
+    <div id="menu">
+        <div class="footer-head">
+            {% include "header.html" %}
+        </div>
+        <div class='footer'>
+            <div class="section-container">
+                {% render_top_level_sections %}
+                {% if show_footers %}
+                    {% render_footer %}
+                {% endif %}
+                <p class='footer__copyright'>{% translate "© The Internet of Good Things" %}</p>
+            </div>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
Closes #1506 

- There was a requirement to hide the double header (search and language dropdown) for JS-enabled devices see #1400 
- Due to the structure of the HTML this change broke the "Menu" button as the Menu button was connected to the double header which is hidden for JS-enabled devices now
- Restructure the HTML and make double header independent of it.