### PR TITLE
updates wagtailmedia version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ wagtail-markdown==0.7.0
 Markdown==3.3.7
 wagtail==2.15.*
 wagtail-cache~=1.2.1
-wagtailmedia==0.7.0
+wagtailmedia==0.10.*
 wagtailmenus~=3.0
 wagtailsvg==0.0.14
 whitenoise==5.2.*


### PR DESCRIPTION
Closes #1508 

- For wagtail >= 2.13 an incompatibility for tabbed interface in chooser panel was introduced see [here](https://github.com/torchbox/wagtailmedia/releases/tag/v0.7.1)
- Updates wagtailmedia package in which this issue has been fixed