### PR TITLE
Randomization between contents

### DIFF
--- a/home/blocks.py
+++ b/home/blocks.py
@@ -191,10 +191,10 @@ class RandomPageButtonBlock(blocks.StructBlock):
 
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context)
-        button_pages = value.get('pages')
-        button_page = random.choice(button_pages).value if button_pages else None
+        live_pages = [page.value for page in value.get('pages') if page.value.live]
+        button_page = random.choice(live_pages) if live_pages else None
 
-        if button_page and button_page.live:
+        if button_page:
             context.update({
                 'button_page': button_page.specific,
                 'text': value.get('text') or button_page.title

--- a/home/blocks.py
+++ b/home/blocks.py
@@ -1,3 +1,5 @@
+import random
+
 from django.conf import settings
 from django.forms.utils import flatatt
 from django.utils.html import format_html, format_html_join
@@ -179,3 +181,25 @@ class DownloadButtonBlock(blocks.StructBlock):
 
     class Meta:
         template = 'blocks/download_button.html'
+
+
+class RandomPageButtonBlock(blocks.StructBlock):
+    pages = blocks.StreamBlock(
+        [("page", blocks.PageChooserBlock())]
+    )
+    text = blocks.CharBlock(required=False, max_length=255)
+
+    def get_context(self, value, parent_context=None):
+        context = super().get_context(value, parent_context)
+        button_pages = value.get('pages')
+        button_page = random.choice(button_pages).value if button_pages else None
+
+        if button_page and button_page.live:
+            context.update({
+                'button_page': button_page.specific,
+                'text': value.get('text') or button_page.title
+            })
+        return context
+
+    class Meta:
+        template = 'blocks/page_button.html'

--- a/home/blocks.py
+++ b/home/blocks.py
@@ -192,13 +192,13 @@ class RandomPageButtonBlock(blocks.StructBlock):
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context)
         live_pages = [page.value for page in value.get('pages') if page.value.live]
-        button_page = random.choice(live_pages) if live_pages else None
-
-        if button_page:
+        if live_pages:
+            button_page = random.choice(live_pages)
             context.update({
                 'button_page': button_page.specific,
                 'text': value.get('text') or button_page.title
             })
+
         return context
 
     class Meta:

--- a/home/models.py
+++ b/home/models.py
@@ -325,6 +325,7 @@ class AbstractArticle(Page, PageUtilsMixin, CommentableMixin, TitleIconMixin):
         ('list', blocks.ListBlock(MarkdownBlock(icon='code'))),
         ('numbered_list', NumberedListBlock(MarkdownBlock(icon='code'))),
         ('page_button', PageButtonBlock()),
+        ('random_page_button', RandomPageButtonBlock()),
         ('embedded_poll', EmbeddedPollBlock()),
         ('embedded_survey', EmbeddedSurveyBlock()),
         ('embedded_quiz', EmbeddedQuizBlock()),

--- a/home/models.py
+++ b/home/models.py
@@ -47,6 +47,7 @@ from comments.models import CommentableMixin, CannedResponse
 from .blocks import (
     MediaBlock, SocialMediaLinkBlock, SocialMediaShareButtonBlock, EmbeddedPollBlock, EmbeddedSurveyBlock,
     EmbeddedQuizBlock, PageButtonBlock, NumberedListBlock, RawHTMLBlock, ArticleBlock, DownloadButtonBlock,
+    RandomPageButtonBlock,
 )
 from .forms import SectionPageForm
 from .mixins import PageUtilsMixin, TitleIconMixin
@@ -65,6 +66,7 @@ class HomePage(Page, PageUtilsMixin, TitleIconMixin):
 
     home_featured_content = StreamField([
         ('page_button', PageButtonBlock()),
+        ('random_page_button', RandomPageButtonBlock()),
         ('embedded_poll', EmbeddedPollBlock()),
         ('embedded_survey', EmbeddedSurveyBlock()),
         ('embedded_quiz', EmbeddedQuizBlock()),

--- a/questionnaires/models.py
+++ b/questionnaires/models.py
@@ -17,7 +17,7 @@ from wagtailmarkdown.blocks import MarkdownBlock
 from wagtailsvg.edit_handlers import SvgChooserPanel
 from wagtailsvg.models import Svg
 
-from home.blocks import MediaBlock, PageButtonBlock, NumberedListBlock, RawHTMLBlock
+from home.blocks import MediaBlock, PageButtonBlock, NumberedListBlock, RawHTMLBlock, RandomPageButtonBlock
 from home.mixins import PageUtilsMixin, TitleIconMixin
 from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import (FieldPanel, InlinePanel,
@@ -66,6 +66,7 @@ class QuestionnairePage(Page, PageUtilsMixin, TitleIconMixin):
             ('list', MarkdownBlock(icon='code')),
             ('numbered_list', NumberedListBlock(MarkdownBlock(icon='code'))),
             ('page_button', PageButtonBlock()),
+            ('random_page_button', RandomPageButtonBlock()),
         ],
         null=True,
         blank=True,
@@ -103,6 +104,7 @@ class QuestionnairePage(Page, PageUtilsMixin, TitleIconMixin):
         [
             ("paragraph", blocks.RichTextBlock(features=settings.WAGTAIL_RICH_TEXT_FIELD_FEATURES)),
             ('page_button', PageButtonBlock()),
+            ('random_page_button', RandomPageButtonBlock()),
         ],
         null=True,
         blank=True,

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Markdown==3.3.7
 wagtail==2.15.*
 wagtail-cache~=1.2.1
 wagtailmedia==0.10.*
-wagtailmenus~=3.0
+wagtailmenus==3.1.3
 wagtailsvg==0.0.14
 whitenoise==5.2.*
 django-health-check==3.16.5


### PR DESCRIPTION
Closes #1547

- A new **Random Page Button** block is introduced, which will serve wagtail pages randomly.
- Admin can add multiple pages.
- The design of this block is same as **Page Button Block**.

### Admin Panel
![image](https://user-images.githubusercontent.com/62539376/220833358-70097327-6bea-41a2-a0c8-137e4c6388d9.png)

### Frontend
![image](https://user-images.githubusercontent.com/62539376/220833636-f582d182-d786-4dc5-87a4-b0cd2ac55b93.png)
