### PR TITLE
Bug/change default cache

### DIFF
--- a/iogt/patch.py
+++ b/iogt/patch.py
@@ -20,15 +20,17 @@ def _translate_node_render(self, context):
     from django.utils.safestring import SafeData
     from django.utils.safestring import mark_safe
     from django.core.cache import cache
+    from translation_manager.models import TranslationEntry
 
-    lookup = (self.filter_expression.var.literal or 
-                self.filter_expression.var._resolve_lookup(context))
+    lookup = self.filter_expression.var.literal or self.filter_expression.var._resolve_lookup(context)
 
     try:
         translation_entry = cache.get(f'{globals_.locale.language_code}_translation_map')[
             (lookup, globals_.locale.language_code)]
     except (KeyError, TypeError):
-        translation_entry = None
+        translation_entry = TranslationEntry.objects.filter(
+            language=globals_.locale.language_code, original=lookup
+        ).first()
 
     if translation_entry and translation_entry.translation:
         return translation_entry.translation

--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -75,7 +75,6 @@ INSTALLED_APPS = [
     'translation_manager',
     'health_check',
     'health_check.db',
-    'health_check.cache',
     'health_check.storage',
     'health_check.contrib.migrations',
     'rest_framework_simplejwt',
@@ -92,6 +91,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.sites',
 ]
+
 
 MIDDLEWARE = [
     'wagtailcache.cache.UpdateCacheMiddleware',
@@ -485,35 +485,34 @@ REST_FRAMEWORK = {
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(days=365),
 }
-
-CACHE_BACKEND = os.getenv('CACHE_BACKEND', 'django.core.cache.backends.dummy.DummyCache')
-if CACHE_BACKEND:
-    DJANGO_REDIS_IGNORE_EXCEPTIONS = True
-    SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
-    WAGTAIL_CACHE_BACKEND = 'pagecache'
-    CACHE_LOCATION = os.getenv('CACHE_LOCATION', '')
-    CACHE_TIMEOUT = int(os.getenv('CACHE_TIMEOUT', '0'))
-    CACHES = {
-        'default': {
-            'BACKEND': CACHE_BACKEND,
-            'LOCATION': CACHE_LOCATION,
-            'TIMEOUT': CACHE_TIMEOUT,
-        },
-        'renditions': {
-            'BACKEND': CACHE_BACKEND,
-            'LOCATION': CACHE_LOCATION,
-            'TIMEOUT': CACHE_TIMEOUT,
-        },
-        'pagecache': {
-            'BACKEND': CACHE_BACKEND,
-            'LOCATION': CACHE_LOCATION,
-            'TIMEOUT': CACHE_TIMEOUT,
-            'KEY_PREFIX': 'pagecache',
-        },
-    }
-else:
-    WAGTAIL_CACHE = False
-    SESSION_ENGINE='django.contrib.sessions.backends.db'
+DUMMY_CACHE_BACKEND = 'django.core.cache.backends.dummy.DummyCache'
+CACHE_BACKEND = os.getenv('CACHE_BACKEND', '') or DUMMY_CACHE_BACKEND
+if CACHE_BACKEND != DUMMY_CACHE_BACKEND:
+    INSTALLED_APPS += [
+        'health_check.cache',
+    ]
+DJANGO_REDIS_IGNORE_EXCEPTIONS = True
+SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
+CACHE_LOCATION = os.getenv('CACHE_LOCATION', '')
+CACHE_TIMEOUT = int(os.getenv('CACHE_TIMEOUT', '0'))
+CACHES = {
+    'default': {
+        'BACKEND': CACHE_BACKEND,
+        'LOCATION': CACHE_LOCATION,
+        'TIMEOUT': CACHE_TIMEOUT,
+    },
+    'renditions': {
+        'BACKEND': CACHE_BACKEND,
+        'LOCATION': CACHE_LOCATION,
+        'TIMEOUT': CACHE_TIMEOUT,
+    },
+    'pagecache': {
+        'BACKEND': CACHE_BACKEND,
+        'LOCATION': CACHE_LOCATION,
+        'TIMEOUT': CACHE_TIMEOUT,
+        'KEY_PREFIX': 'pagecache',
+    },
+}
 
 SITE_VERSION = os.getenv('SITE_VERSION', 'unknown')
 

--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -486,7 +486,7 @@ SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(days=365),
 }
 
-CACHE_BACKEND = os.getenv('CACHE_BACKEND')
+CACHE_BACKEND = os.getenv('CACHE_BACKEND', 'django.core.cache.backends.dummy.DummyCache')
 if CACHE_BACKEND:
     DJANGO_REDIS_IGNORE_EXCEPTIONS = True
     SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'


### PR DESCRIPTION
By default, Django uses Local Memory Cache see [here](https://docs.djangoproject.com/en/4.1/topics/cache/#local-memory-caching) if a cache isn't explicitly specified. And Django requires that the default cache be configured otherwise an error is raised.
<img width="992" alt="Screenshot 2023-02-28 at 10 53 10 AM" src="https://user-images.githubusercontent.com/49383675/221766307-6b41fbfc-ccdb-4192-9621-710029d79423.png">

To simulate no cache behavior we can use Dummy Cache see [here](https://docs.djangoproject.com/en/4.1/topics/cache/#dummy-caching-for-development), it just provides an interface for cache without actually doing any caching so code doesn't break.