### PR TITLE
unicode escape for superset datasets

### DIFF
--- a/questionnaires/superset/utils.py
+++ b/questionnaires/superset/utils.py
@@ -31,16 +31,16 @@ CHART_TYPE_MAP = {
 }
 
 CALCULATED_COLUMN_EXPRESSION_MAP = {
-    'checkbox': "((form_data::json)->'{}')::text",
-    'checkboxes': "trim(both '\"' from json_array_elements((form_data::json)->'{}')::TEXT)",
-    'dropdown': "trim(both '\"' from ((form_data::json)->'{}')::text)",
-    'email': "trim(both '\"' from ((form_data::json)->'{}')::text)",
-    'singleline': "((form_data::json)->'{}')::text",
-    'multiline': "((form_data::json)->'{}')::text",
+    'checkbox': "unistr(((form_data::json)->'{}')::text)",
+    'checkboxes': "unistr(trim(both '\"' from json_array_elements((form_data::json)->'{}')::text))",
+    'dropdown': "unistr(trim(both '\"' from ((form_data::json)->'{}')::text))",
+    'email': "unistr(trim(both '\"' from ((form_data::json)->'{}')::text))",
+    'singleline': "unistr(((form_data::json)->'{}')::text)",
+    'multiline': "unistr(((form_data::json)->'{}')::text)",
     'number': "(form_data::json->>'{}')::DECIMAL",
     'positivenumber': "(form_data::json->>'{}')::DECIMAL",
-    'radio': "trim(both '\"' from ((form_data::json)->'{}')::text)",
-    'url': "trim(both '\"' from ((form_data::json)->'{}')::text)",
+    'radio': "unistr(trim(both '\"' from ((form_data::json)->'{}')::text))",
+    'url': "unistr(trim(both '\"' from ((form_data::json)->'{}')::text))",
 }
 
 


### PR DESCRIPTION
Fixes #861 

- Unicode comma `\u2019` was used in V1.
<img width="533" alt="Screenshot 2023-03-01 at 4 15 45 PM" src="https://user-images.githubusercontent.com/49383675/222134249-2a4fc4ce-59ac-4330-af9b-b37d6c8ea400.png">

- Escape it and render it as a normal string
<img width="535" alt="Screenshot 2023-03-01 at 4 13 10 PM" src="https://user-images.githubusercontent.com/49383675/222134277-57efd5e7-9f64-4c65-b4bb-9b68eee6cb12.png">
