### PR TITLE
Fix alignment issue for images on child Section Pages in Section Pages List

### DIFF
--- a/home/static/css/global/global.css
+++ b/home/static/css/global/global.css
@@ -130,7 +130,7 @@
   -webkit-box-pack: justify;
       -ms-flex-pack: justify;
           justify-content: space-between;
-  padding: 8px 12px;
+  padding: 8px 0px;
   border-bottom: 1px solid #EFEFEF;
   font-style: normal;
   font-weight: bold;

--- a/home/static/css/global/global.css
+++ b/home/static/css/global/global.css
@@ -172,7 +172,7 @@
 
 @media only screen and (min-width: 360px) {
   .sub-section {
-    padding: 8px 20px 8px 0px;
+    padding: 8px 0px;
     font-size: 16px;
     line-height: 22px;
   }
@@ -702,10 +702,6 @@
 .article-card .img-holder, .section-card .img-holder {
   overflow: hidden;
   position: relative;
-}
-
-.section-card .img-holder {
-  padding-left: 20px;
 }
 
 .article-card .img-holder.complete:after, .section-card .img-holder.complete:after {


### PR DESCRIPTION
Closes #1578

- Child Section Pages in the list have images that are aligned with other Page types.

![image](https://user-images.githubusercontent.com/62539376/225852584-687a1cc3-b696-440e-882e-c34973072f68.png)
