### PR TITLE
Explicitly define datetime format for API

### DIFF
--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -480,6 +480,7 @@ WAGTAILTRANSFER_LOOKUP_FIELDS = {
 }
 
 REST_FRAMEWORK = {
+    'DATETIME_FORMAT': '%Y-%m-%dT%H:%M:%S.%fZ',
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework_simplejwt.authentication.JWTAuthentication',


### PR DESCRIPTION
Closes #1599 

It explicitly defines the datetime format for Django Rest Framework (DRF) as "%Y-%m-%dT%H:%M:%S.%fZ" to ensure consistency in the format of datetime objects across the application. This ensures that our datetime objects are always formatted consistently