### PR TITLE
Fix translating a page - MultipleObjectsReturned

### DIFF
--- a/home/management/commands/check_multiple_translation_sources.py
+++ b/home/management/commands/check_multiple_translation_sources.py
@@ -12,7 +12,5 @@ class Command(BaseCommand):
                     specific_content_type=page.content_type_id,
                     translations__target_locale=page.locale,
                 )
-            except TranslationSource.DoesNotExist:
-                pass
             except TranslationSource.MultipleObjectsReturned:
-                self.stdout.write(f"=======> {page.id} {page.title}")
+                self.stdout.write(f"Page ID:{page.id} Page Title:{page.title}")

--- a/home/management/commands/check_multiple_translation_sources.py
+++ b/home/management/commands/check_multiple_translation_sources.py
@@ -6,13 +6,13 @@ from wagtail_localize.models import TranslationSource
 class Command(BaseCommand):
     def handle(self, *args, **options):
         for page in Page.objects.all():
-            try:
-                TranslationSource.objects.get(
-                    object_id=page.translation_key,
-                    specific_content_type=page.content_type_id,
-                    translations__target_locale=page.locale,
-                )
-            except TranslationSource.DoesNotExist:
-                pass
-            except TranslationSource.MultipleObjectsReturned:
-                self.stdout.write(f"Multiple translation sources found for page:{page.id}, title:{page.title}")
+            translation_sources = TranslationSource.objects.filter(
+                object_id=page.translation_key,
+                specific_content_type=page.content_type_id,
+                translations__target_locale=page.locale,
+            )
+
+            if translation_sources.count() > 1:
+                self.stdout.write(f"Multiple translation sources found for page: {page.id}, title: {page.title}")
+                for translation_source in translation_sources:
+                    self.stdout.write(f" - Translation source: {translation_source.id}, locale: {translation_source.locale}")

--- a/home/management/commands/check_multiple_translation_sources.py
+++ b/home/management/commands/check_multiple_translation_sources.py
@@ -5,12 +5,14 @@ from wagtail_localize.models import TranslationSource
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        for page in Page.objects.filter(translation_key__isnull=False):
+        for page in Page.objects.all():
             try:
                 TranslationSource.objects.get(
                     object_id=page.translation_key,
                     specific_content_type=page.content_type_id,
                     translations__target_locale=page.locale,
                 )
+            except TranslationSource.DoesNotExist:
+                pass
             except TranslationSource.MultipleObjectsReturned:
-                self.stdout.write(f"Page ID:{page.id} Page Title:{page.title}")
+                self.stdout.write(f"Multiple translation sources found for page:{page.id}, title:{page.title}")

--- a/home/management/commands/check_multiple_translation_sources.py
+++ b/home/management/commands/check_multiple_translation_sources.py
@@ -1,0 +1,18 @@
+from django.core.management import BaseCommand
+from wagtail.core.models import Page
+from wagtail_localize.models import TranslationSource
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        for page in Page.objects.filter(translation_key__isnull=False):
+            try:
+                TranslationSource.objects.get(
+                    object_id=page.translation_key,
+                    specific_content_type=page.content_type_id,
+                    translations__target_locale=page.locale,
+                )
+            except TranslationSource.DoesNotExist:
+                pass
+            except TranslationSource.MultipleObjectsReturned:
+                self.stdout.write(f"=======> {page.id} {page.title}")

--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -566,3 +566,8 @@ MATOMO_TRACKING = os.getenv('MATOMO_TRACKING', 'disable') == 'enable'
 
 # Width size options are 360, 750
 IMAGE_SIZE_PRESET = int(os.getenv('IMAGE_SIZE_PRESET', '') or '360')
+
+# Default primary key field type introduced in Django 3.2 or later versions
+# https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,14 +6,14 @@ django-debug-toolbar==3.2.1
 django-extensions==3.1.*
 django-sass-processor==1.0.*
 django-translation-manager~=1.3.0
-django==3.1.*
+django==3.2.0
 elasticsearch~=7.16
 libsass==0.21.*
 lxml==4.8.*
 psycopg2==2.8.*
 redis~=3.0
 tqdm==4.62.*
-wagtail-localize==1.2.1
+wagtail-localize==1.3.3
 wagtail-markdown==0.7.0
 Markdown==3.3.7
 wagtail==2.15.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-debug-toolbar==3.2.1
 django-extensions==3.1.*
 django-sass-processor==1.0.*
 django-translation-manager~=1.3.0
-django==3.2.0
+django==3.2.*
 elasticsearch~=7.16
 libsass==0.21.*
 lxml==4.8.*


### PR DESCRIPTION
Closes #1604

## Write a management command to identify the pages with multiple translation sources.
   - **Command**: python manage.py check_multiple_translation_sources

## Update packages
- Django: 3.2.0
- wagtail-localize: 1.3.3

## Default auto field
- Default auto field added in settings 