### PR TITLE
Remove redundant test configuration

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,37 +1,22 @@
 version: '3.5'
 
 services:
-
   django:
     build:
       context: ./
       dockerfile: Dockerfile.dev
     environment:
-      BASE_URL: 'http://localhost:8000'
-      DB_CONN_MAX_AGE: '600'
       DB_HOST: db
       DB_NAME: iogt
       DB_PASSWORD: iogt
       DB_PORT: '5432'
       DB_USER: iogt
-      DB_SSL_MODE: allow
-      DEBUG: enable
       DJANGO_SETTINGS_MODULE: iogt.settings.test
-      COMMIT_HASH: asdfghjkl
-      SECRET_KEY: secret_key
-      WAGTAILTRANSFER_SECRET_KEY: wagtailtransfer-secret-key
-      WAGTAILTRANSFER_SOURCE_NAME: iogt_global
-      WAGTAILTRANSFER_SOURCE_BASE_URL: https://example.com/wagtail-transfer/
-      WAGTAILTRANSFER_SOURCE_SECRET_KEY: wagtailtransfer-source-secret-key
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - ./:/app/
-    ports:
-      - '8000:8000'
     depends_on:
-      - elasticsearch
       - db
-
   db:
     image: postgres:alpine
     restart: unless-stopped
@@ -39,20 +24,3 @@ services:
       POSTGRES_USER: iogt
       POSTGRES_PASSWORD: iogt
       POSTGRES_DB: iogt
-    volumes:
-      - iogt_postgres_data:/var/lib/postgresql/data/
-    ports:
-      - 5432:5432
-
-  elasticsearch:
-    image: 'docker.elastic.co/elasticsearch/elasticsearch:7.12.1'
-    environment:
-      - discovery.type=single-node
-    volumes:
-      - iogt_elasticsearch_data:/usr/share/elasticsearch/data
-    ports:
-      - "9200:9200"
-
-volumes:
-  iogt_postgres_data:
-  iogt_elasticsearch_data:

--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -251,7 +251,7 @@ WAGTAIL_USER_CUSTOM_FIELDS = ['display_name', 'first_name', 'last_name', 'email'
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
-BASE_URL = os.getenv('BASE_URL')
+BASE_URL = os.getenv('BASE_URL', '')
 
 # SITE ID
 SITE_ID = 1

--- a/iogt/settings/test.py
+++ b/iogt/settings/test.py
@@ -1,6 +1,6 @@
 from .base import *
 
-SECRET_KEY = "nAHoNtaAFSBrVJhLbNfzbwMc751QFvby"
+SECRET_KEY = "##secret_key_for_testing##"
 
 DATABASES = {
     'default': {
@@ -10,20 +10,9 @@ DATABASES = {
         'PASSWORD': os.environ.get('DB_PASSWORD'),
         'HOST': os.environ.get('DB_HOST'),
         'PORT': os.environ.get('DB_PORT'),
-        'CONN_MAX_AGE': int(os.getenv('DB_CONN_MAX_AGE', '0')),
     }
 }
 
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 
 DEBUG = True
-
-ALLOWED_HOSTS = ['*']
-
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
-STATIC_URL = '/static/'
-
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
-MEDIA_URL = '/media/'


### PR DESCRIPTION
There is a lot of configuration settings in the various test configuration files that seem unnecessary, and removing them will allow us to see which settings _are_ important, without affecting the tests.