### PR TITLE
Reduce number of warning messages in test logs

### DIFF
--- a/home/tests/tests.py
+++ b/home/tests/tests.py
@@ -1,13 +1,20 @@
+from bs4 import BeautifulSoup
 from django.test import TestCase, override_settings
 from django.http import HttpRequest
 from translation_manager.models import TranslationEntry
 from wagtail.core.models import Site
+from wagtail_factories import SiteFactory, PageFactory
 from wagtail_localize.operations import TranslationCreator
 
 from home.wagtail_hooks import limit_page_chooser
-from home.factories import SectionFactory, ArticleFactory, HomePageFactory, MediaFactory, LocaleFactory, SiteSettingsFactory
-from wagtail_factories import SiteFactory, PageFactory
-from bs4 import BeautifulSoup
+from home.factories import (
+    SectionFactory,
+    ArticleFactory,
+    HomePageFactory,
+    MediaFactory,
+    LocaleFactory,
+    SiteSettingsFactory
+)
 
 
 class LimitPageChooserHookTests(TestCase):
@@ -109,7 +116,7 @@ class ImageResizeTest(TestCase):
 
     def test_default_image_within_preset(self):
         response = self.client.get(self.article.url)
-        parsed_response = BeautifulSoup(response.content)
+        parsed_response = parse_html(response.content)
         rendered_image = parsed_response.find("img", {"class": "article__lead-img-featured"})
         image_rendition = self.article.lead_image.get_rendition('width-360')
 
@@ -122,7 +129,7 @@ class ImageResizeTest(TestCase):
 
     def test_half_default_image_within_preset(self):
         response = self.client.get(self.section.url)
-        parsed_response = BeautifulSoup(response.content)
+        parsed_response = parse_html(response.content)
         rendered_image = parsed_response.find("div", {"class": "article-card"}).find("img")
         image_rendition = self.article.lead_image.get_rendition('width-180')
 
@@ -135,7 +142,7 @@ class ImageResizeTest(TestCase):
     @override_settings(IMAGE_SIZE_PRESET=750)
     def test_custom_image_within_preset(self):
         response = self.client.get(self.article.url)
-        parsed_response = BeautifulSoup(response.content)
+        parsed_response = parse_html(response.content)
         rendered_image = parsed_response.find("img", {"class": "article__lead-img-featured"})
         image_rendition = self.article.lead_image.get_rendition('width-750')
 
@@ -148,7 +155,7 @@ class ImageResizeTest(TestCase):
     @override_settings(IMAGE_SIZE_PRESET=750)
     def test_half_custom_image_within_preset(self):
         response = self.client.get(self.section.url)
-        parsed_response = BeautifulSoup(response.content)
+        parsed_response = parse_html(response.content)
         rendered_image = parsed_response.find("div", {"class": "article-card"}).find("img")
         image_rendition = self.article.lead_image.get_rendition('width-375')
 
@@ -157,3 +164,7 @@ class ImageResizeTest(TestCase):
         self.assertEqual(int(rendered_image.get('width')), image_rendition.width)
         self.assertEqual(int(rendered_image.get('height')), image_rendition.height)
         self.assertEqual(rendered_image.get('src'), image_rendition.url)
+
+
+def parse_html(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, 'lxml')

--- a/questionnaires/api/v1/tests.py
+++ b/questionnaires/api/v1/tests.py
@@ -4,7 +4,6 @@ import json
 from datetime import timedelta
 
 import pytz
-from bs4 import BeautifulSoup
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.urls import reverse
@@ -16,6 +15,7 @@ from wagtail.core.models import Site
 from wagtail_factories import SiteFactory, PageFactory
 
 from home.factories import HomePageFactory
+from home.tests.tests import parse_html
 from iogt_users.factories import (
     UserFactory,
     GroupFactory,
@@ -1128,7 +1128,3 @@ class TestQuestionnaireSubmitButtonText(TestCase):
         PollFormFieldFactory(page=poll, field_type='checkboxes', choices='c1|c2|c3')
 
         self.assertEqual(poll.get_submit_button_text(), "Submit")
-
-
-def parse_html(html: str) -> BeautifulSoup:
-    return BeautifulSoup(html, 'lxml')

--- a/questionnaires/api/v1/tests.py
+++ b/questionnaires/api/v1/tests.py
@@ -14,6 +14,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 from wagtail.core.models import Site
 from wagtail_factories import SiteFactory, PageFactory
+
 from home.factories import HomePageFactory
 from iogt_users.factories import (
     UserFactory,
@@ -1053,7 +1054,7 @@ class PollTest(TestCase):
         PollFormFieldFactory(page=self.poll, field_type='dropdown', choices='c1|c2')
 
         response = self.client.get(self.poll.url)
-        parsed_response = BeautifulSoup(response.content)
+        parsed_response = parse_html(response.content)
         default_drop_down_option = parsed_response.select_one('.quest-item select option').text
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1063,7 +1064,7 @@ class PollTest(TestCase):
         poll_question = PollFormFieldFactory(page=self.poll, field_type='dropdown', choices='c1|c2')
 
         response = self.client.post(self.poll.url, {poll_question.clean_name: ''})
-        parsed_response = BeautifulSoup(response.content)
+        parsed_response = parse_html(response.content)
         field_required_text = parsed_response.select_one('.quest-item .cust-input__error').text
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1073,7 +1074,7 @@ class PollTest(TestCase):
         poll_question = PollFormFieldFactory(page=self.poll, field_type='dropdown', choices='c1|c2', required=False)
 
         response = self.client.post(self.poll.url, {poll_question.clean_name: ''})
-        parsed_response = BeautifulSoup(response.content)
+        parsed_response = parse_html(response.content)
         results = parsed_response.select('.cust-check__title')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1087,7 +1088,7 @@ class PollTest(TestCase):
         poll_question = PollFormFieldFactory(page=self.poll, field_type='dropdown', choices='c1|c2')
 
         response = self.client.post(self.poll.url, {poll_question.clean_name: 'c1'})
-        parsed_response = BeautifulSoup(response.content)
+        parsed_response = parse_html(response.content)
         results = parsed_response.select('.cust-check__title')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1127,3 +1128,7 @@ class TestQuestionnaireSubmitButtonText(TestCase):
         PollFormFieldFactory(page=poll, field_type='checkboxes', choices='c1|c2|c3')
 
         self.assertEqual(poll.get_submit_button_text(), "Submit")
+
+
+def parse_html(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, 'lxml')


### PR DESCRIPTION
There are repeated warnings about the BeautifulSoup HTML parser appearing in the logs while the unit tests are running. The warnings might obscure more important problems that may occur during test runs. The fix is simply to specify exactly which parser to use - I have set it to 'lxml'.