### PR TITLE
Hide chatbot authentication string

### DIFF
--- a/messaging/templates/messaging/tags/chatbot_auth_tokens.html
+++ b/messaging/templates/messaging/tags/chatbot_auth_tokens.html
@@ -1,6 +1,18 @@
 <span style="font-weight: bold">Chatbot Authentication Headers</span>
 <p style="text-transform: none; display: inline-block">
-{% for username, token in tokens.items %}
-    <div style="word-wrap: break-word; width: 80%"><strong>{{ username }}:</strong> {{ token }}</div>
-{% endfor %}
+  {% for username, token in tokens.items %}
+    <div style="word-wrap: break-word; width: 80%">
+      <strong>{{ username }}:</strong> 
+      <span class="hidden", style="display:none;">{{ token }}</span>
+      <button onclick="toggleVisibility(this)">Reveal Token</button>
+    </div>
+  {% endfor %}
 </p>
+
+<script>
+    function toggleVisibility(button) {
+        var tokenSpan = button.previousElementSibling;
+        tokenSpan.classList.toggle("hidden");
+        button.textContent = (tokenSpan.classList.contains("hidden")) ? "Reveal Token" : "Hide Token";
+}
+</script>

--- a/messaging/templates/messaging/tags/chatbot_auth_tokens.html
+++ b/messaging/templates/messaging/tags/chatbot_auth_tokens.html
@@ -3,16 +3,16 @@
   {% for username, token in tokens.items %}
     <div style="word-wrap: break-word; width: 80%">
       <strong>{{ username }}:</strong> 
-      <span class="hidden", style="display:none;">{{ token }}</span>
-      <button onclick="toggleVisibility(this)">Reveal Token</button>
+      <span class="hidden" style="display: none;">{{ token }}</span>
+      <button onclick="toggleVisibility(this)" style="display: inline-block;">Reveal Token</button>
     </div>
   {% endfor %}
 </p>
 
 <script>
-    function toggleVisibility(button) {
-        var tokenSpan = button.previousElementSibling;
-        tokenSpan.classList.toggle("hidden");
-        button.textContent = (tokenSpan.classList.contains("hidden")) ? "Reveal Token" : "Hide Token";
+function toggleVisibility(button) {
+  var tokenSpan = button.previousElementSibling;
+  tokenSpan.style.display = (tokenSpan.style.display === "none") ? "inline-block" : "none";
+  button.textContent = (tokenSpan.style.display === "none") ? "Reveal Token" : "Hide Token";
 }
 </script>


### PR DESCRIPTION
Resolving issue #1614. The chatbot token is now hidden with a click to reveal functionality. 