### PR TITLE
Show entire comment to community moderators

### DIFF
--- a/comments/templates/comments/community_moderation.html
+++ b/comments/templates/comments/community_moderation.html
@@ -31,6 +31,8 @@
                 <tr>
                     <td class="comment-moderation-comment">
                         {{ comment.comment }}
+                        <br>
+                        <a href="{{ comment.content_object.get_absolute_url }}" style="color: blue; text-decoration: underline;" target="_blank">Link to Comment</a>
                     </td>
                     <td class="width-32">
                         <div class="action-btn">

--- a/iogt/static/css/iogt.css
+++ b/iogt/static/css/iogt.css
@@ -2498,9 +2498,10 @@ input[type=checkbox], input[type=radio] {
     position: relative;
     display: inline-block;
     width: 300px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+    word-wrap: break-word;
 }
 
 .comment-moderation {


### PR DESCRIPTION
Include the entire text of comments in Community Comment Moderation, and link to the comments. Issue #1602 resolved. 