### PR TITLE
Track additional site ID with Matomo

### DIFF
--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -559,6 +559,7 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = int(os.getenv('DATA_UPLOAD_MAX_NUMBER_FIELDS', '
 
 # Matomo tracking server and site information
 
+MATOMO_ADDITIONAL_SITE_ID = int(os.getenv('MATOMO_ADDITIONAL_SITE_ID', '0'))
 MATOMO_SERVER_URL = os.getenv('MATOMO_SERVER_URL', '')
 MATOMO_SITE_ID = int(os.getenv('MATOMO_SITE_ID', '') or '0')
 MATOMO_TRACKING = os.getenv('MATOMO_TRACKING', 'disable') == 'enable'

--- a/matomo/templates/matomo_tracking_tags.html
+++ b/matomo/templates/matomo_tracking_tags.html
@@ -9,12 +9,18 @@
         var u="{{ matomo_server_url }}";
         _paq.push(['setTrackerUrl', u+'matomo.php']);
         _paq.push(['setSiteId', '{{ matomo_site_id }}']);
+        {% if matomo_additional_site_id %}
+        _paq.push(['addTracker', u+'matomo.php', '{{ matomo_additional_site_id }}']);
+        {% endif %}
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
       })();
     </script>
     <noscript>
       <img src="{{ matomo_server_url }}matomo.php?idsite={{ matomo_site_id }}&rec=1" style="border:0" alt="" />
+      {% if matomo_additional_site_id %}
+      <img src="{{ matomo_server_url }}matomo.php?idsite={{ matomo_additional_site_id }}&rec=1" style="border:0" alt="" />
+      {% endif %}
     </noscript>
 {% endif %}
 <!-- End Matomo Code -->

--- a/matomo/templatetags/matomo_tags.py
+++ b/matomo/templatetags/matomo_tags.py
@@ -5,15 +5,22 @@ from django.conf import settings
 register = template.Library()
 
 
-@register.inclusion_tag('matomo_tracking_tags.html', takes_context=True)
+@register.inclusion_tag("matomo_tracking_tags.html", takes_context=True)
 def matomo_tracking_tags(context):
-    context.update({
-        'tracking_enabled': (
+    context.update(
+        {
+            "tracking_enabled": (
                 settings.MATOMO_TRACKING
                 and settings.MATOMO_SERVER_URL
                 and settings.MATOMO_SITE_ID
-        ),
-        'matomo_site_id': settings.MATOMO_SITE_ID,
-        'matomo_server_url': settings.MATOMO_SERVER_URL
-    })
+            ),
+            "matomo_site_id": settings.MATOMO_SITE_ID,
+            "matomo_server_url": settings.MATOMO_SERVER_URL,
+        }
+    )
+
+    additional_site_id = settings.MATOMO_ADDITIONAL_SITE_ID
+    if type(additional_site_id) is int and additional_site_id > 0:
+        context.update({"matomo_additional_site_id": additional_site_id})
+
     return context

--- a/matomo/tests/test_matomo_tags.py
+++ b/matomo/tests/test_matomo_tags.py
@@ -1,0 +1,35 @@
+from django.test import TestCase, override_settings
+
+from matomo.templatetags.matomo_tags import matomo_tracking_tags
+
+
+@override_settings(
+    MATOMO_TRACKING=True,
+    MATOMO_SERVER_URL="https://example.com/",
+    MATOMO_SITE_ID=456,
+)
+class MatomoTagsTests(TestCase):
+    def test_only_enabled_when_required_settings_are_set(self):
+        self.assertTrue(matomo_tracking_tags(dict()).get("tracking_enabled"))
+
+    def test_additional_site_id_must_be_positive_integer(self):
+        with override_settings(MATOMO_ADDITIONAL_SITE_ID=567):
+            self.assertEqual(
+                matomo_tracking_tags(dict()).get("matomo_additional_site_id"),
+                567,
+            )
+
+        with override_settings(MATOMO_ADDITIONAL_SITE_ID=0):
+            self.assertFalse(
+                "matomo_additional_site_id" in matomo_tracking_tags(dict())
+            )
+
+        with override_settings(MATOMO_ADDITIONAL_SITE_ID=None):
+            self.assertFalse(
+                "matomo_additional_site_id" in matomo_tracking_tags(dict())
+            )
+
+        with override_settings(MATOMO_ADDITIONAL_SITE_ID='123'):
+            self.assertFalse(
+                "matomo_additional_site_id" in matomo_tracking_tags(dict())
+            )


### PR DESCRIPTION
The purpose of this feature is to allow tracking of the same site to two different site IDs in Matomo. This is deemed necessary to emulate what was occurring with Google Analytics before the migration to Matomo. Each site is tracked individually via its own site ID and in aggregate with other sites via a 'global' site ID. The global site ID tracks metrics from all sites to allow an overview for IoGT project management, whereas the individual site ID is for UNICEF country offices to view the metrics from their own site only.