### PR TITLE
Create session-based user tracking ID

### DIFF
--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -560,6 +560,7 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = int(os.getenv('DATA_UPLOAD_MAX_NUMBER_FIELDS', '
 # Matomo tracking server and site information
 
 MATOMO_ADDITIONAL_SITE_ID = int(os.getenv('MATOMO_ADDITIONAL_SITE_ID', '0'))
+MATOMO_CREATE_VISITOR_ID = os.getenv('MATOMO_CREATE_VISITOR_ID', 'disable') == 'enable'
 MATOMO_SERVER_URL = os.getenv('MATOMO_SERVER_URL', '')
 MATOMO_SITE_ID = int(os.getenv('MATOMO_SITE_ID', '') or '0')
 MATOMO_TRACKING = os.getenv('MATOMO_TRACKING', 'disable') == 'enable'

--- a/matomo/templates/matomo_tracking_tags.html
+++ b/matomo/templates/matomo_tracking_tags.html
@@ -2,7 +2,7 @@
 {% if tracking_enabled %}
     <script type="text/javascript">
       var _paq = window._paq = window._paq || [];
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['setUserId', '{{ matomo_user_id }}']);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/matomo/templates/matomo_tracking_tags.html
+++ b/matomo/templates/matomo_tracking_tags.html
@@ -2,7 +2,6 @@
 {% if tracking_enabled %}
     <script type="text/javascript">
       var _paq = window._paq = window._paq || [];
-      _paq.push(['setUserId', '{{ matomo_user_id }}']);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/matomo/templates/matomo_tracking_tags.html
+++ b/matomo/templates/matomo_tracking_tags.html
@@ -17,10 +17,10 @@
       })();
     </script>
     <noscript>
-      <img src="{{ matomo_server_url }}matomo.php?idsite={{ matomo_site_id }}&rec=1" style="border:0" alt="" />
-      {% if matomo_additional_site_id %}
-      <img src="{{ matomo_server_url }}matomo.php?idsite={{ matomo_additional_site_id }}&rec=1" style="border:0" alt="" />
-      {% endif %}
+        <img src="{{ matomo_image_tracker_url }}" style="border:0" alt="" />
+        {% if matomo_additional_image_tracker_url %}
+        <img src="{{ matomo_additional_image_tracker_url }}" style="border:0" alt="" />
+        {% endif %}
     </noscript>
 {% endif %}
 <!-- End Matomo Code -->

--- a/matomo/templatetags/matomo_tags.py
+++ b/matomo/templatetags/matomo_tags.py
@@ -1,8 +1,12 @@
 from uuid import uuid4
+from hashlib import sha1
+from datetime import datetime
 
 from django import template
 from django.conf import settings
 
+
+VISITOR_ID_KEY = "vid"
 register = template.Library()
 
 
@@ -10,15 +14,14 @@ register = template.Library()
 def matomo_tracking_tags(context):
     server_url = settings.MATOMO_SERVER_URL
     site_id = settings.MATOMO_SITE_ID
-    uid = user_tracking_id(context["request"].session)
+    vid = visitor_id(context["request"])
 
     context.update(
         {
             "tracking_enabled": (settings.MATOMO_TRACKING and server_url and site_id),
             "matomo_site_id": site_id,
             "matomo_server_url": server_url,
-            "matomo_image_tracker_url": image_tracker(server_url, site_id, uid),
-            "matomo_user_id": uid,
+            "matomo_image_tracker_url": image_tracker(server_url, site_id, vid),
         }
     )
 
@@ -28,7 +31,7 @@ def matomo_tracking_tags(context):
             {
                 "matomo_additional_site_id": additional_site_id,
                 "matomo_additional_image_tracker_url": image_tracker(
-                    server_url, additional_site_id, uid
+                    server_url, additional_site_id, vid
                 ),
             }
         )
@@ -36,12 +39,25 @@ def matomo_tracking_tags(context):
     return context
 
 
-def user_tracking_id(session):
-    if not session.get("tid"):
-        session["tid"] = str(uuid4())
+def visitor_id(request):
+    session = request.session
 
-    return session["tid"]
+    if not session.get(VISITOR_ID_KEY):
+        session[VISITOR_ID_KEY] = generate_random_id()
+
+    return session[VISITOR_ID_KEY]
 
 
-def image_tracker(server_url, site_id, uid):
-    return f"{server_url}matomo.php?idsite={site_id}&rec=1&uid={uid}"
+def generate_random_id():
+    return sha1(
+        "".join(
+            [
+                datetime.now().isoformat(),
+                str(uuid4()),
+            ]
+        ).encode("utf-8")
+    ).hexdigest()[0:16]
+
+
+def image_tracker(server_url, site_id, vid):
+    return f"{server_url}matomo.php?idsite={site_id}&rec=1&_id={vid}"

--- a/matomo/templatetags/matomo_tags.py
+++ b/matomo/templatetags/matomo_tags.py
@@ -12,31 +12,62 @@ register = template.Library()
 
 @register.inclusion_tag("matomo_tracking_tags.html", takes_context=True)
 def matomo_tracking_tags(context):
+    enabled = is_enabled()
+
+    if not enabled:
+        return context.update({"tracking_enabled": enabled})
+
     server_url = settings.MATOMO_SERVER_URL
     site_id = settings.MATOMO_SITE_ID
-    vid = visitor_id(context["request"])
+    vid = create_visitor_id(context)
 
     context.update(
         {
-            "tracking_enabled": (settings.MATOMO_TRACKING and server_url and site_id),
+            "tracking_enabled": enabled,
             "matomo_site_id": site_id,
             "matomo_server_url": server_url,
             "matomo_image_tracker_url": image_tracker(server_url, site_id, vid),
         }
     )
-
-    additional_site_id = settings.MATOMO_ADDITIONAL_SITE_ID
-    if type(additional_site_id) is int and additional_site_id > 0:
-        context.update(
-            {
-                "matomo_additional_site_id": additional_site_id,
-                "matomo_additional_image_tracker_url": image_tracker(
-                    server_url, additional_site_id, vid
-                ),
-            }
-        )
+    context.update(additional_site_id(server_url, vid))
 
     return context
+
+
+def is_enabled():
+    try:
+        return (
+            settings.MATOMO_TRACKING
+            and settings.MATOMO_SERVER_URL
+            and settings.MATOMO_SITE_ID
+        )
+    except AttributeError:
+        return False
+
+
+def create_visitor_id(context):
+    try:
+        if settings.MATOMO_CREATE_VISITOR_ID:
+            return visitor_id(context["request"])
+    except AttributeError:
+        return None
+
+
+def additional_site_id(server_url, vid=None):
+    try:
+        site_id = settings.MATOMO_ADDITIONAL_SITE_ID
+    except AttributeError:
+        return {}
+
+    if type(site_id) is int and site_id > 0:
+        return {
+            "matomo_additional_site_id": site_id,
+            "matomo_additional_image_tracker_url": image_tracker(
+                server_url, site_id, vid
+            ),
+        }
+    else:
+        return {}
 
 
 def visitor_id(request):
@@ -59,5 +90,10 @@ def generate_random_id():
     ).hexdigest()[0:16]
 
 
-def image_tracker(server_url, site_id, vid):
-    return f"{server_url}matomo.php?idsite={site_id}&rec=1&_id={vid}"
+def image_tracker(server_url, site_id, vid=None):
+    url = f"{server_url}matomo.php?idsite={site_id}&rec=1"
+
+    if vid:
+        url += f"&_id={vid}"
+
+    return url

--- a/matomo/templatetags/matomo_tags.py
+++ b/matomo/templatetags/matomo_tags.py
@@ -18,6 +18,7 @@ def matomo_tracking_tags(context):
             "matomo_site_id": site_id,
             "matomo_server_url": server_url,
             "matomo_image_tracker_url": image_tracker(server_url, site_id, uid),
+            "matomo_user_id": uid,
         }
     )
 

--- a/matomo/templatetags/matomo_tags.py
+++ b/matomo/templatetags/matomo_tags.py
@@ -1,26 +1,46 @@
+from uuid import uuid4
+
 from django import template
 from django.conf import settings
-
 
 register = template.Library()
 
 
 @register.inclusion_tag("matomo_tracking_tags.html", takes_context=True)
 def matomo_tracking_tags(context):
+    server_url = settings.MATOMO_SERVER_URL
+    site_id = settings.MATOMO_SITE_ID
+    uid = user_tracking_id(context["request"].session)
+
     context.update(
         {
-            "tracking_enabled": (
-                settings.MATOMO_TRACKING
-                and settings.MATOMO_SERVER_URL
-                and settings.MATOMO_SITE_ID
-            ),
-            "matomo_site_id": settings.MATOMO_SITE_ID,
-            "matomo_server_url": settings.MATOMO_SERVER_URL,
+            "tracking_enabled": (settings.MATOMO_TRACKING and server_url and site_id),
+            "matomo_site_id": site_id,
+            "matomo_server_url": server_url,
+            "matomo_image_tracker_url": image_tracker(server_url, site_id, uid),
         }
     )
 
     additional_site_id = settings.MATOMO_ADDITIONAL_SITE_ID
     if type(additional_site_id) is int and additional_site_id > 0:
-        context.update({"matomo_additional_site_id": additional_site_id})
+        context.update(
+            {
+                "matomo_additional_site_id": additional_site_id,
+                "matomo_additional_image_tracker_url": image_tracker(
+                    server_url, additional_site_id, uid
+                ),
+            }
+        )
 
     return context
+
+
+def user_tracking_id(session):
+    if not session.get("tid"):
+        session["tid"] = str(uuid4())
+
+    return session["tid"]
+
+
+def image_tracker(server_url, site_id, uid):
+    return f"{server_url}matomo.php?idsite={site_id}&rec=1&uid={uid}"

--- a/matomo/tests/test_matomo_tags.py
+++ b/matomo/tests/test_matomo_tags.py
@@ -10,26 +10,35 @@ from matomo.templatetags.matomo_tags import matomo_tracking_tags
 )
 class MatomoTagsTests(TestCase):
     def test_only_enabled_when_required_settings_are_set(self):
-        self.assertTrue(matomo_tracking_tags(dict()).get("tracking_enabled"))
+        self.assertTrue(matomo_tracking_tags(create_context()).get("tracking_enabled"))
 
     def test_additional_site_id_must_be_positive_integer(self):
         with override_settings(MATOMO_ADDITIONAL_SITE_ID=567):
             self.assertEqual(
-                matomo_tracking_tags(dict()).get("matomo_additional_site_id"),
+                matomo_tracking_tags(create_context()).get("matomo_additional_site_id"),
                 567,
             )
 
         with override_settings(MATOMO_ADDITIONAL_SITE_ID=0):
             self.assertFalse(
-                "matomo_additional_site_id" in matomo_tracking_tags(dict())
+                "matomo_additional_site_id" in matomo_tracking_tags(create_context())
             )
 
         with override_settings(MATOMO_ADDITIONAL_SITE_ID=None):
             self.assertFalse(
-                "matomo_additional_site_id" in matomo_tracking_tags(dict())
+                "matomo_additional_site_id" in matomo_tracking_tags(create_context())
             )
 
-        with override_settings(MATOMO_ADDITIONAL_SITE_ID='123'):
+        with override_settings(MATOMO_ADDITIONAL_SITE_ID="123"):
             self.assertFalse(
-                "matomo_additional_site_id" in matomo_tracking_tags(dict())
+                "matomo_additional_site_id" in matomo_tracking_tags(create_context())
             )
+
+
+class MockRequest:
+    def __init__(self):
+        self.session = dict()
+
+
+def create_context():
+    return {"request": MockRequest()}

--- a/matomo/tests/test_matomo_tags.py
+++ b/matomo/tests/test_matomo_tags.py
@@ -14,24 +14,33 @@ class MatomoTagsTests(TestCase):
 
     def test_additional_site_id_must_be_positive_integer(self):
         with override_settings(MATOMO_ADDITIONAL_SITE_ID=567):
+            context = matomo_tracking_tags(create_context())
+            self.assertEqual(context.get("matomo_additional_site_id"), 567)
             self.assertEqual(
-                matomo_tracking_tags(create_context()).get("matomo_additional_site_id"),
-                567,
+                context.get("matomo_additional_image_tracker_url"),
+                "https://example.com/matomo.php?idsite=567&rec=1",
             )
 
         with override_settings(MATOMO_ADDITIONAL_SITE_ID=0):
-            self.assertFalse(
-                "matomo_additional_site_id" in matomo_tracking_tags(create_context())
-            )
+            context = matomo_tracking_tags(create_context())
+            self.assertFalse("matomo_additional_site_id" in context)
+            self.assertFalse("matomo_additional_image_tracker_url" in context)
 
         with override_settings(MATOMO_ADDITIONAL_SITE_ID=None):
-            self.assertFalse(
-                "matomo_additional_site_id" in matomo_tracking_tags(create_context())
-            )
+            context = matomo_tracking_tags(create_context())
+            self.assertFalse("matomo_additional_site_id" in context)
+            self.assertFalse("matomo_additional_image_tracker_url" in context)
 
         with override_settings(MATOMO_ADDITIONAL_SITE_ID="123"):
-            self.assertFalse(
-                "matomo_additional_site_id" in matomo_tracking_tags(create_context())
+            context = matomo_tracking_tags(create_context())
+            self.assertFalse("matomo_additional_site_id" in context)
+            self.assertFalse("matomo_additional_image_tracker_url" in context)
+
+    def test_visitor_id_is_created_for_clients_without_javascript(self):
+        with override_settings(MATOMO_CREATE_VISITOR_ID=True):
+            self.assertRegexpMatches(
+                matomo_tracking_tags(create_context()).get("matomo_image_tracker_url"),
+                r"_id=[a-f0-9]{16}",
             )
 
 


### PR DESCRIPTION
When JavaScript is disabled in the browser, we use the Matomo Image Tracker to gather analytics data. In this case, first party cookies are also disabled and Matomo is not able to differentiate between different visitors very well. The tracking ID is intended to provide the same function as the visitor ID that is usually provided by Matomo when JS is enabled.