### PR TITLE
Upgrade wagtail-transfer to v0.8.5

### DIFF
--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -440,10 +440,6 @@ TRANSLATIONS_BASE_DIR = BASE_DIR
 # ========= Rapid Pro =================
 RAPIDPRO_BOT_GROUP_NAME = os.getenv('RAPIDPRO_BOT_GROUP_NAME', 'rapidpro_chatbot')
 
-# Wagtail transfer default values. Override these in local.py
-WAGTAILTRANSFER_SECRET_KEY = os.getenv('WAGTAILTRANSFER_SECRET_KEY')
-WAGTAILTRANSFER_SOURCES = {}
-
 WAGTAILMENUS_FLAT_MENU_ITEMS_RELATED_NAME = 'iogt_flat_menu_items'
 
 WAGTAIL_RICH_TEXT_FIELD_FEATURES = [
@@ -471,13 +467,20 @@ TRANSLATIONS_PROJECT_BASE_DIR = BASE_DIR
 
 from iogt.patch import *
 
-WAGTAILTRANSFER_UPDATE_RELATED_MODELS = ['wagtailimages.image', 'wagtailsvg.svg',]
-WAGTAILTRANSFER_SHOW_ERROR_FOR_REFERENCED_PAGES = True
 WAGTAILTRANSFER_LOOKUP_FIELDS = {
     'taggit.tag': ['slug'],
     'wagtailcore.locale': ['language_code'],
     'iogt_users.user': ['username'],
 }
+WAGTAILTRANSFER_SECRET_KEY = os.getenv('WAGTAILTRANSFER_SECRET_KEY')
+WAGTAILTRANSFER_SHOW_ERROR_FOR_REFERENCED_PAGES = True
+WAGTAILTRANSFER_SOURCES = {
+   os.getenv('WAGTAILTRANSFER_SOURCE_NAME', 'default'): {
+      'BASE_URL': os.getenv('WAGTAILTRANSFER_SOURCE_BASE_URL'),
+      'SECRET_KEY': os.getenv('WAGTAILTRANSFER_SOURCE_SECRET_KEY'),
+   },
+}
+WAGTAILTRANSFER_UPDATE_RELATED_MODELS = ['wagtailimages.image', 'wagtailsvg.svg',]
 
 REST_FRAMEWORK = {
     'DATETIME_FORMAT': '%Y-%m-%dT%H:%M:%S.%fZ',

--- a/iogt/settings/production.py
+++ b/iogt/settings/production.py
@@ -19,14 +19,6 @@ DATABASES = {
     }
 }
 
-WAGTAILTRANSFER_SECRET_KEY = os.environ.get('WAGTAILTRANSFER_SECRET_KEY')
-WAGTAILTRANSFER_SOURCES = {
-   os.environ.get('WAGTAILTRANSFER_SOURCE_NAME', 'default'): {
-      'BASE_URL': os.environ.get('WAGTAILTRANSFER_SOURCE_BASE_URL'),
-      'SECRET_KEY': os.environ.get('WAGTAILTRANSFER_SOURCE_SECRET_KEY'),
-   },
-}
-
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1134,8 +1134,8 @@ wagtail-markdown==0.10.0 \
     --hash=sha256:b16be4b6e3518cc6dd15ab335cbc6d6a9122b5d7e3a61fa11c83597e2660044e \
     --hash=sha256:e4a97eee0211eebaab9c850669e647bc1c8ceb70df38b4db5a2c3d8b02ebaf69
     # via -r requirements.txt
-wagtail-transfer @ https://github.com/IDEMSInternational/wagtail-transfer/archive/408edb5d432ac72dc2727a1847e0f294b8d6efa6.zip \
-    --hash=sha256:cac600baa5572bc328194b5ee6c7e2e57b333da23a6a4d63b8f4b38694d9c6a1
+wagtail-transfer @ https://github.com/IDEMSInternational/wagtail-transfer/archive/52b57b364ebc9acddd412ee708f829b45763c9ab.zip \
+    --hash=sha256:049c23e1406564d3b7e8c385e72051f34e707add4f8109d874da670711709548
     # via -r requirements.txt
 wagtailmedia==0.12.0 \
     --hash=sha256:0807515c5d89782666b613de2e4aedab19e9dd358097fad2cb79633c0b5416d3 \

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,6 @@ djangorestframework-simplejwt==5.0.0
 djangorestframework~=3.13.1
 drf-yasg~=1.21.3
 elasticsearch~=7.16
-https://github.com/IDEMSInternational/wagtail-transfer/archive/408edb5d432ac72dc2727a1847e0f294b8d6efa6.zip#egg=wagtail-transfer
 libsass==0.21.*
 lxml~=4.9.1
 psycopg2~=2.9.9
@@ -34,4 +33,6 @@ wagtail~=3.0.3
 wagtailmedia~=0.12.0
 wagtailmenus==3.1.3
 wagtailsvg==0.0.37
+# branch: iogt, tag: v0.8.5-iogt.1
+wagtail-transfer @ https://github.com/IDEMSInternational/wagtail-transfer/archive/52b57b364ebc9acddd412ee708f829b45763c9ab.zip
 whitenoise==5.2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -882,8 +882,8 @@ wagtail-markdown==0.10.0 \
     --hash=sha256:b16be4b6e3518cc6dd15ab335cbc6d6a9122b5d7e3a61fa11c83597e2660044e \
     --hash=sha256:e4a97eee0211eebaab9c850669e647bc1c8ceb70df38b4db5a2c3d8b02ebaf69
     # via -r requirements.in
-wagtail-transfer @ https://github.com/IDEMSInternational/wagtail-transfer/archive/408edb5d432ac72dc2727a1847e0f294b8d6efa6.zip \
-    --hash=sha256:cac600baa5572bc328194b5ee6c7e2e57b333da23a6a4d63b8f4b38694d9c6a1
+wagtail-transfer @ https://github.com/IDEMSInternational/wagtail-transfer/archive/52b57b364ebc9acddd412ee708f829b45763c9ab.zip \
+    --hash=sha256:049c23e1406564d3b7e8c385e72051f34e707add4f8109d874da670711709548
     # via -r requirements.in
 wagtailmedia==0.12.0 \
     --hash=sha256:0807515c5d89782666b613de2e4aedab19e9dd358097fad2cb79633c0b5416d3 \


### PR DESCRIPTION
The recent upgrade to Wagtail v3 is incompatible with the currently used version of wagtail-transfer (v0.8.3). Upgrading wagtail-transfer will fix the incompatibility.

Resolves #1684 