### PR TITLE
Fix bug related to Wagtail Transfer and content types

### DIFF
--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -435,10 +435,15 @@ WAGTAILMARKDOWN = {
 TRANSLATIONS_PROJECT_BASE_DIR = BASE_DIR
 
 WAGTAILTRANSFER_LOOKUP_FIELDS = {
+    'contenttypes.contenttype': ['app_label', 'model'],
+    'iogt_users.user': ['username'],
     'taggit.tag': ['slug'],
     'wagtailcore.locale': ['language_code'],
-    'iogt_users.user': ['username'],
 }
+WAGTAILTRANSFER_NO_FOLLOW_MODELS = [
+    'contenttypes.contenttype',
+    'wagtailcore.page',
+]
 WAGTAILTRANSFER_SECRET_KEY = os.getenv('WAGTAILTRANSFER_SECRET_KEY')
 WAGTAILTRANSFER_SHOW_ERROR_FOR_REFERENCED_PAGES = True
 WAGTAILTRANSFER_SOURCES = {


### PR DESCRIPTION
Only match content types using the 'app_label' and 'model' fields, and do not follow content types if they appear in other models.